### PR TITLE
Feature/23 Board update API

### DIFF
--- a/src/main/java/com/sscanner/team/board/controller/BoardController.java
+++ b/src/main/java/com/sscanner/team/board/controller/BoardController.java
@@ -1,7 +1,8 @@
 package com.sscanner.team.board.controller;
 
 import com.sscanner.team.board.requestdto.BoardCreateRequestDTO;
-import com.sscanner.team.board.responsedto.BoardCreateResponseDTO;
+import com.sscanner.team.board.requestdto.BoardUpdateRequestDTO;
+import com.sscanner.team.board.responsedto.BoardResponseDTO;
 import com.sscanner.team.board.service.BoardService;
 import com.sscanner.team.global.common.response.ApiResponse;
 import jakarta.validation.Valid;
@@ -19,9 +20,9 @@ public class BoardController {
     private final BoardService boardService;
 
     @PostMapping()
-    public ApiResponse<BoardCreateResponseDTO> createAddBoard(@Valid @RequestPart(value = "data") BoardCreateRequestDTO boardCreateRequestDTO,
-                                                              @RequestPart(value = "files") List<MultipartFile> files) {
-        BoardCreateResponseDTO board = boardService.createBoard(boardCreateRequestDTO, files);
+    public ApiResponse<BoardResponseDTO> createAddBoard(@Valid @RequestPart(value = "data") BoardCreateRequestDTO boardCreateRequestDTO,
+                                                        @RequestPart(value = "files") List<MultipartFile> files) {
+        BoardResponseDTO board = boardService.createBoard(boardCreateRequestDTO, files);
 
         return ApiResponse.ok(201, board, "쓰레기통 신고 게시글 저장 완료!!");
     }
@@ -31,5 +32,14 @@ public class BoardController {
         boardService.deleteBoard(boardId);
 
         return ApiResponse.ok(200, "게시판 삭제 완료!!");
+    }
+
+    @PatchMapping("/{boardId}")
+    public ApiResponse<BoardResponseDTO> updateBoard(@PathVariable Long boardId,
+                                     @RequestPart(value = "data") BoardUpdateRequestDTO boardUpdateRequestDTO,
+                                     @RequestPart(value = "files", required = false) List<MultipartFile> files) {
+        BoardResponseDTO board = boardService.updateBoard(boardId, boardUpdateRequestDTO, files);
+
+        return ApiResponse.ok(200, board, "게시판 수정 완료!!");
     }
 }

--- a/src/main/java/com/sscanner/team/board/entity/Board.java
+++ b/src/main/java/com/sscanner/team/board/entity/Board.java
@@ -1,6 +1,7 @@
 package com.sscanner.team.board.entity;
 
 import com.sscanner.team.User;
+import com.sscanner.team.board.requestdto.BoardUpdateRequestDTO;
 import com.sscanner.team.board.type.BoardCategory;
 import com.sscanner.team.global.common.BaseEntity;
 import com.sscanner.team.trashcan.type.TrashCategory;
@@ -13,8 +14,6 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.List;
 
 import static lombok.AccessLevel.PROTECTED;
 
@@ -66,9 +65,6 @@ public class Board extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private TrashcanStatus updatedTrashcanStatus;
 
-    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL)
-    private List<BoardImg> boardImgs = new ArrayList<>();
-
     @Builder
     public Board(User user,
                  BoardCategory boardCategory,
@@ -93,9 +89,14 @@ public class Board extends BaseEntity {
         this.updatedTrashcanStatus = updatedTrashcanStatus;
     }
 
-    public void addBoardImgs(List<BoardImg> boardImgs) {
-        for(BoardImg boardImg : boardImgs) {
-            this.boardImgs.add(boardImg);
-        }
+    public void updateBoardInfo(BoardUpdateRequestDTO boardUpdateRequestDTO) {
+        this.significant = boardUpdateRequestDTO.significant();
+        this.trashcanId = boardUpdateRequestDTO.trashcanId();
+        this.latitude = boardUpdateRequestDTO.latitude();
+        this.longitude = boardUpdateRequestDTO.longitude();
+        this.roadNameAddress = boardUpdateRequestDTO.roadNameAddress();
+        this.detailedAddress = boardUpdateRequestDTO.detailedAddress();
+        this.trashCategory = boardUpdateRequestDTO.trashCategory();
+        this.updatedTrashcanStatus = boardUpdateRequestDTO.updatedTrashcanStatus();
     }
 }

--- a/src/main/java/com/sscanner/team/board/entity/BoardImg.java
+++ b/src/main/java/com/sscanner/team/board/entity/BoardImg.java
@@ -5,7 +5,6 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 import static lombok.AccessLevel.PROTECTED;
@@ -15,28 +14,26 @@ import static lombok.AccessLevel.PROTECTED;
 @Table(name = "Board_img")
 @NoArgsConstructor(access = PROTECTED)
 @SQLRestriction("deleted_at IS NULL")
-@SQLDelete(sql = "UPDATE board_img SET deleted_at = NOW() WHERE board_img_id = ?")
 public class BoardImg extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "board_img_id", nullable = false)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "board_id", nullable = false)
-    private Board board;
+    @Column(name = "board_id", nullable = false)
+    private Long boardId;
 
     @Column(name = "board_img_url", nullable = false)
     private String boardImgUrl;
 
     @Builder
-    public BoardImg(Board board, String boardImgUrl) {
-        this.board = board;
+    public BoardImg(Long boardId, String boardImgUrl) {
+        this.boardId = boardId;
         this.boardImgUrl = boardImgUrl;
     }
 
-    public static BoardImg makeBoardImg(Board board, String boardImgUrl) {
+    public static BoardImg makeBoardImg(Long boardId, String boardImgUrl) {
         return BoardImg.builder()
-                .board(board)
+                .boardId(boardId)
                 .boardImgUrl(boardImgUrl)
                 .build();
     }

--- a/src/main/java/com/sscanner/team/board/repository/BoardImgRepository.java
+++ b/src/main/java/com/sscanner/team/board/repository/BoardImgRepository.java
@@ -2,7 +2,16 @@ package com.sscanner.team.board.repository;
 
 import com.sscanner.team.board.entity.BoardImg;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface BoardImgRepository extends JpaRepository<BoardImg, Long> {
+    List<BoardImg> findAllByBoardId(Long boardId);
 
+    @Modifying
+    @Query("update BoardImg bi set bi.deletedAt = NOW() where bi.boardId = :boardId")
+    void deleteAll(@Param("boardId") Long boardId);
 }

--- a/src/main/java/com/sscanner/team/board/requestdto/BoardUpdateRequestDTO.java
+++ b/src/main/java/com/sscanner/team/board/requestdto/BoardUpdateRequestDTO.java
@@ -1,0 +1,42 @@
+package com.sscanner.team.board.requestdto;
+
+import com.sscanner.team.trashcan.type.TrashCategory;
+import com.sscanner.team.trashcan.type.TrashcanStatus;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.math.BigDecimal;
+
+public record BoardUpdateRequestDTO(
+        @NotNull(message = "userId는 필수입니다.")
+        String userId,
+
+        String significant,
+
+        Long trashcanId,
+
+        @NotNull(message = "위도 작성은 필수입니다.")
+        @DecimalMin(value = "-90.0", message = "위도는 -90 이상이어야 합니다.")
+        @DecimalMax(value = "90.0", message = "위도는 90 이하이어야 합니다.")
+        BigDecimal latitude,
+
+        @NotNull(message = "경도 작성은 필수입니다.")
+        @DecimalMin(value = "-180.0", message = "경도는 -180 이상이어야 합니다.")
+        @DecimalMax(value = "180.0", message = "경도는 180 이하이어야 합니다.")
+        BigDecimal longitude,
+
+        @NotBlank(message = "도로명 주소 작성은 필수입니다.")
+        String roadNameAddress,
+
+        @NotBlank(message = "상세 주소 작성은 필수입니다.")
+        String detailedAddress,
+
+        @NotNull(message = "쓰레기통 유형 작성은 필수입니다.")
+        TrashCategory trashCategory,
+
+        @NotNull(message = "쓰레기통 상태 작성은 필수입니다.")
+        TrashcanStatus updatedTrashcanStatus
+) {
+}

--- a/src/main/java/com/sscanner/team/board/responsedto/BoardImgResponseDTO.java
+++ b/src/main/java/com/sscanner/team/board/responsedto/BoardImgResponseDTO.java
@@ -2,11 +2,11 @@ package com.sscanner.team.board.responsedto;
 
 import com.sscanner.team.board.entity.BoardImg;
 
-public record BoardImgCreateResponseDTO(
+public record BoardImgResponseDTO(
         String boardImgUrl
 ) {
-    public static BoardImgCreateResponseDTO of(BoardImg boardImg) {
-        return new BoardImgCreateResponseDTO(
+    public static BoardImgResponseDTO of(BoardImg boardImg) {
+        return new BoardImgResponseDTO(
                 boardImg.getBoardImgUrl());
     }
 }

--- a/src/main/java/com/sscanner/team/board/responsedto/BoardResponseDTO.java
+++ b/src/main/java/com/sscanner/team/board/responsedto/BoardResponseDTO.java
@@ -8,23 +8,23 @@ import com.sscanner.team.trashcan.type.TrashcanStatus;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public record BoardCreateResponseDTO(
+public record BoardResponseDTO(
     Long id,
     Long trashcanId,
     BoardCategory boardCategory,
     String significant,
     TrashcanStatus updatedTrashcanStatus,
-    List<BoardImgCreateResponseDTO> boardImgs
+    List<BoardImgResponseDTO> boardImgs
 ) {
-    public static BoardCreateResponseDTO from(Board board) {
-        return new BoardCreateResponseDTO(
+    public static BoardResponseDTO from(Board board, List<BoardImg> boardImgs) {
+        return new BoardResponseDTO(
                 board.getId(),
                 board.getTrashcanId(),
                 board.getBoardCategory(),
                 board.getSignificant(),
                 board.getUpdatedTrashcanStatus(),
-                board.getBoardImgs().stream()
-                        .map((BoardImg boardImg) -> BoardImgCreateResponseDTO.of(boardImg))
+                boardImgs.stream()
+                        .map((BoardImg boardImg) -> BoardImgResponseDTO.of(boardImg))
                         .collect(Collectors.toList())
         );
     }

--- a/src/main/java/com/sscanner/team/board/service/BoardImgService.java
+++ b/src/main/java/com/sscanner/team/board/service/BoardImgService.java
@@ -1,11 +1,13 @@
 package com.sscanner.team.board.service;
 
-import com.sscanner.team.board.entity.Board;
 import com.sscanner.team.board.entity.BoardImg;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 public interface BoardImgService {
-    List<BoardImg> saveBoardImg(Board board, List<MultipartFile> files);
+    List<BoardImg> saveBoardImg(Long boardId, List<MultipartFile> files);
+    void deleteBoardImgs(Long boardId);
+    List<BoardImg> updateBoardImgs(Long boardId, List<MultipartFile> files);
+    List<BoardImg> getBoardImgs(Long boardId);
 }

--- a/src/main/java/com/sscanner/team/board/service/BoardImgServiceImpl.java
+++ b/src/main/java/com/sscanner/team/board/service/BoardImgServiceImpl.java
@@ -1,9 +1,10 @@
 package com.sscanner.team.board.service;
 
-import com.sscanner.team.board.entity.Board;
 import com.sscanner.team.board.entity.BoardImg;
 import com.sscanner.team.board.repository.BoardImgRepository;
 import com.sscanner.team.global.common.service.ImageService;
+import com.sscanner.team.global.exception.BadRequestException;
+import com.sscanner.team.global.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -11,6 +12,8 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import static com.sscanner.team.global.exception.ExceptionCode.*;
 
 
 @Service
@@ -22,16 +25,40 @@ public class BoardImgServiceImpl implements BoardImgService{
     private final ImageService imageService;
 
     @Override
-    public List<BoardImg> saveBoardImg(Board board, List<MultipartFile> files) {
+    public List<BoardImg> saveBoardImg(Long boardId, List<MultipartFile> files) {
         List<BoardImg> boardImgs = new ArrayList<>();
         for(MultipartFile file : files) {
             String boardImgUrl = imageService.makeImgUrl(file);
 
-            BoardImg boardImg = BoardImg.makeBoardImg(board, boardImgUrl);
+            BoardImg boardImg = BoardImg.makeBoardImg(boardId, boardImgUrl);
 
             boardImgs.add(boardImg);
         }
 
         return boardImgRepository.saveAll(boardImgs);
+    }
+
+    @Override
+    public void deleteBoardImgs(Long boardId) {
+        List<BoardImg> boardImgs = getBoardImgs(boardId);
+
+        boardImgRepository.deleteAll(boardId);
+    }
+
+    @Override
+    public List<BoardImg> updateBoardImgs(Long boardId, List<MultipartFile> files) {
+        deleteBoardImgs(boardId);
+
+        return saveBoardImg(boardId, files);
+    }
+
+    @Override
+    public List<BoardImg> getBoardImgs(Long boardId) {
+        List<BoardImg> boardImgs = boardImgRepository.findAllByBoardId(boardId);
+        if(boardImgs.isEmpty()) {
+            throw new BadRequestException(NOT_EXIST_BOARD_IMG);
+        }
+
+        return boardImgs;
     }
 }

--- a/src/main/java/com/sscanner/team/board/service/BoardService.java
+++ b/src/main/java/com/sscanner/team/board/service/BoardService.java
@@ -2,14 +2,19 @@ package com.sscanner.team.board.service;
 
 import com.sscanner.team.board.entity.Board;
 import com.sscanner.team.board.requestdto.BoardCreateRequestDTO;
-import com.sscanner.team.board.responsedto.BoardCreateResponseDTO;
+import com.sscanner.team.board.requestdto.BoardUpdateRequestDTO;
+import com.sscanner.team.board.responsedto.BoardResponseDTO;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 public interface BoardService {
-    BoardCreateResponseDTO createBoard(BoardCreateRequestDTO boardCreateRequestDTO,
-                                          List<MultipartFile> files);
+    BoardResponseDTO createBoard(BoardCreateRequestDTO boardCreateRequestDTO,
+                                 List<MultipartFile> files);
     void deleteBoard(Long boardId);
+    BoardResponseDTO updateBoard(Long boardId,
+                                 BoardUpdateRequestDTO boardUpdateRequestDTO,
+                                 List<MultipartFile> files);
+
     Board getBoard(Long boardId);
 }

--- a/src/main/java/com/sscanner/team/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/sscanner/team/board/service/BoardServiceImpl.java
@@ -1,29 +1,33 @@
 package com.sscanner.team.board.service;
 
+import com.sscanner.team.User;
 import com.sscanner.team.board.entity.Board;
 import com.sscanner.team.board.entity.BoardImg;
 import com.sscanner.team.board.repository.BoardRepository;
 import com.sscanner.team.board.requestdto.BoardCreateRequestDTO;
-import com.sscanner.team.board.responsedto.BoardCreateResponseDTO;
+import com.sscanner.team.board.requestdto.BoardUpdateRequestDTO;
+import com.sscanner.team.board.responsedto.BoardResponseDTO;
 import com.sscanner.team.global.exception.BadRequestException;
-import com.sscanner.team.global.exception.ExceptionCode;
+import com.sscanner.team.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
-import java.util.Optional;
 
 import static com.sscanner.team.global.exception.ExceptionCode.*;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class BoardServiceImpl implements BoardService{
 
     private final BoardRepository boardRepository;
     private final BoardImgService boardImgService;
+    private final UserRepository userRepository;
 
     /**
      * 추가, 수정, 삭제 신고 게시글 등록
@@ -33,25 +37,57 @@ public class BoardServiceImpl implements BoardService{
      */
     @Transactional
     @Override
-    public BoardCreateResponseDTO createBoard(BoardCreateRequestDTO boardCreateRequestDTO,
-                                                 List<MultipartFile> files) {
+    public BoardResponseDTO createBoard(BoardCreateRequestDTO boardCreateRequestDTO,
+                                        List<MultipartFile> files) {
+        User user = userRepository.findById(boardCreateRequestDTO.userId()).get();
         // null에 user 들어갈 예정
-        Board addBoard = boardCreateRequestDTO.toEntityAddBoard(null);
+        Board addBoard = boardCreateRequestDTO.toEntityAddBoard(user);
 
         Board savedAddBoard = boardRepository.save(addBoard);
 
-        List<BoardImg> boardImgs = boardImgService.saveBoardImg(savedAddBoard, files);
-        savedAddBoard.addBoardImgs(boardImgs);
+        List<BoardImg> boardImgs = boardImgService.saveBoardImg(savedAddBoard.getId(), files);
 
-        return BoardCreateResponseDTO.from(savedAddBoard);
+        return BoardResponseDTO.from(savedAddBoard, boardImgs);
     }
 
+    /**
+     * 신고 게시글 논리 삭제
+     * @param boardId - 게시글 id
+     */
     @Transactional
     @Override
     public void deleteBoard(Long boardId) {
         Board board = getBoard(boardId);
 
+        boardImgService.deleteBoardImgs(board.getId());
+
         boardRepository.delete(board);
+    }
+
+    /**
+     * 게시글 수정
+     * @param boardId - 게시글 id
+     * @param boardUpdateRequestDTO - Body
+     * @param files - 변경된 이미지 파일들
+     * @return BoardResponseDTO
+     */
+    @Transactional
+    @Override
+    public BoardResponseDTO updateBoard(Long boardId,
+                                           BoardUpdateRequestDTO boardUpdateRequestDTO,
+                                           List<MultipartFile> files) {
+        Board board = getBoard(boardId);
+
+        board.updateBoardInfo(boardUpdateRequestDTO);
+
+        List<BoardImg> boardImgs;
+        if(files.get(0).isEmpty()) {
+            boardImgs = boardImgService.getBoardImgs(boardId);
+        } else {
+            boardImgs = boardImgService.updateBoardImgs(board.getId(), files);
+        }
+
+        return BoardResponseDTO.from(board, boardImgs);
     }
 
     @Override

--- a/src/main/java/com/sscanner/team/global/exception/ExceptionCode.java
+++ b/src/main/java/com/sscanner/team/global/exception/ExceptionCode.java
@@ -36,6 +36,7 @@ public enum ExceptionCode {
     NOT_EXIST_TRASHCAN_ID(400, "해당하는 쓰레기통이 존재하지 않습니다."),
     NOT_EXIST_FILE(400, "파일이 비어있습니다."),
     NOT_EXIST_BOARD(400, "해당하는 게시글이 존재하지 않습니다."),
+    NOT_EXIST_BOARD_IMG(400, "해당하는 게시글의 이미지가 존재하지 않습니다."),
     FILE_UPLOAD_FAIL(400,  "파일 업로드를 실패하였습니다."),
     DUPLICATED_EMAIL(409, "이미 가입된 이메일입니다. "),
     DUPLICATED_NICKNAME(409, "이미 가입된 닉네임입니다. "),


### PR DESCRIPTION
resolved : #23 
## 📌 과제 설명 
- Board와 BoardImg 연관관계 끊기
- Board update 기능 구현

## 👩‍💻 요구 사항과 구현 내용
- Board와 BoardImg는 라이프 사이클이 다르기 때문에 연관관계를 끊어 복잡성을 낮춘다
- 벌크 연산을 통해 Board 삭제 시 BoardImg의 deleted_at을 NOW()로 업데이트한다. -> 쿼리가 한 번만 나간다.
- 업데이트 과정에서 사진 업로드는 선택 -> MultipartFile은 isEmpty()를 통해 null을 체크한다.
- 게시글 업데이트 기능 구현

## ✅ 피드백 반영사항 

## ✅ PR 포인트 & 궁금한 점 
- ResponseDTO를 위주로 보고 요구사항에 맞게 코드를 작성했는지 리뷰 부탁드립니다
- 벌크 연산을 사용해서 update 쿼리를 한 번만 나가게 하였습니다. 한 번씩 보시고 사용해봐도 좋을 것 같아요!! 제가 작성했던 관련 블로그 링크 달아 놓겠습니다. 
[벌크 연산 링크](https://velog.io/@hunil99/%EB%B2%8C%ED%81%AC-%EC%97%B0%EC%82%B0%EC%9D%B4-%EB%AD%90%EC%95%BC-%EC%99%9C-%EC%82%AC%EC%9A%A9%ED%95%B4%EC%A3%BC%EC%9D%98%ED%95%A0-%EC%A0%90)