### PR TITLE
Feature/22 쓰레기통 이미지 등록, 조회 API 구현

### DIFF
--- a/src/main/java/com/sscanner/team/global/common/service/ImageServiceImpl.java
+++ b/src/main/java/com/sscanner/team/global/common/service/ImageServiceImpl.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.util.IOUtils;
 import com.sscanner.team.global.exception.BadRequestException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -21,9 +22,11 @@ import static com.sscanner.team.global.exception.ExceptionCode.*;
 @RequiredArgsConstructor
 public class ImageServiceImpl implements ImageService{
 
-    private final AmazonS3 amazonS3;
-    private static final String BASE_URL = "https://sscanner-bucket.s3.ap-northeast-2.amazonaws.com";
-    private static final String BUCKET = "sscanner-bucket";
+    private final AmazonS3 s3Client;
+    @Value("${sscanner.bucket.base-url}")
+    private String baseUrl;
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
 
     /**
      * 이미지 url 생성
@@ -43,7 +46,7 @@ public class ImageServiceImpl implements ImageService{
 
         uploadS3(file, fileName); // S3에 이미지 업로드
 
-        return BASE_URL + "/" + fileName;
+        return baseUrl + "/" + fileName;
     }
 
     /**
@@ -93,8 +96,8 @@ public class ImageServiceImpl implements ImageService{
             objMeta.setContentLength(bytes.length); // 파일의 크기
 
             // PutObjectRequest를 사용하여 지정된 S3 버킷에 파일을 업로드
-            amazonS3.putObject(
-                    new PutObjectRequest(BUCKET, fileName, file.getInputStream(), objMeta)
+            s3Client.putObject(
+                    new PutObjectRequest(bucket, fileName, file.getInputStream(), objMeta)
                             .withCannedAcl(CannedAccessControlList.PublicRead)); // ACL을 PublicRead로 하여 공용으로 읽을 수 있도록 권한 부여
         } catch (IOException e) {
             throw new BadRequestException(FILE_UPLOAD_FAIL);

--- a/src/main/java/com/sscanner/team/global/configure/S3Config.java
+++ b/src/main/java/com/sscanner/team/global/configure/S3Config.java
@@ -4,6 +4,7 @@ import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -11,22 +12,22 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class S3Config {
-    @Value("${aws.access-key}")
+
+    @Value("${cloud.aws.credentials.accessKey}")
     private String accessKey;
 
-    @Value("${aws.secret-key}")
+    @Value("${cloud.aws.credentials.secretKey}")
     private String secretKey;
 
-    @Value("${aws.region.static}")
+    @Value("${cloud.aws.region.static}")
     private String region;
 
-    @Bean
-    public AmazonS3 getS3ClientBean() {
-        AWSCredentials credentials = new BasicAWSCredentials(this.accessKey, this.secretKey);
-
-        return AmazonS3ClientBuilder.standard()
-                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+    @Bean(name = "s3Client")
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
                 .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCreds))
                 .build();
     }
 }

--- a/src/main/java/com/sscanner/team/global/exception/ExceptionCode.java
+++ b/src/main/java/com/sscanner/team/global/exception/ExceptionCode.java
@@ -30,6 +30,7 @@ public enum ExceptionCode {
 
     //Unsupported Media Type
     BAD_FILE_EXTENSION(415, "적절하지 않은 파일 확장자입니다."),
+    INVALID_FILE_NAME(415, "파일 이름이 잘못되었습니다."),
 
     //BAD REQUEST
     NOT_EXIST_TRASHCAN_ID(400, "해당하는 쓰레기통이 존재하지 않습니다."),

--- a/src/main/java/com/sscanner/team/global/exception/ExceptionCode.java
+++ b/src/main/java/com/sscanner/team/global/exception/ExceptionCode.java
@@ -47,7 +47,8 @@ public enum ExceptionCode {
     DUPLICATED_NICKNAME(409, "이미 가입된 닉네임입니다. "),
     DUPLICATED_PHONE(409, "이미 가입된 핸드폰 번호입니다. "),
     PASSWORD_NOT_MATCH(400, "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
-    USER_NOT_FOUND(400,"해당 유저가 존재하지 않습니다.");
+    USER_NOT_FOUND(400,"해당 유저가 존재하지 않습니다."),
+    NOT_EXIST_TRASHCAN_IMG_ID(400, "해당하는 쓰레기통 이미지가 존재하지 않습니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/sscanner/team/trashcan/controller/TrashcanApiController.java
+++ b/src/main/java/com/sscanner/team/trashcan/controller/TrashcanApiController.java
@@ -5,10 +5,14 @@ import com.sscanner.team.global.common.response.ApiResponse;
 import com.sscanner.team.trashcan.requestDto.RegisterTrashcanRequestDto;
 import com.sscanner.team.trashcan.requestDto.UpdateTrashcanRequestDto;
 import com.sscanner.team.trashcan.responseDto.TrashcanResponseDto;
+import com.sscanner.team.trashcan.responseDto.TrashcanWithImgResponseDto;
+import com.sscanner.team.trashcan.service.TrashcanImgService;
 import com.sscanner.team.trashcan.service.TrashcanService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 
 @RequiredArgsConstructor
@@ -19,27 +23,28 @@ public class TrashcanApiController {
     private final TrashcanService trashcanService;
 
     @PostMapping()
-    public ApiResponse<TrashcanResponseDto> registerTrashcan(@RequestBody @Valid RegisterTrashcanRequestDto requestDto){
+    public ApiResponse<TrashcanWithImgResponseDto> registerTrashcan(@RequestPart(value = "data") @Valid RegisterTrashcanRequestDto requestDto,
+                                                                     @RequestPart(value = "file") MultipartFile file){
 
-        TrashcanResponseDto responseDto = trashcanService.registerTrashcan(requestDto);
+        TrashcanWithImgResponseDto responseDto = trashcanService.registerTrashcan(requestDto, file);
 
         return ApiResponse.ok(201, responseDto, "쓰레기통 등록 성공");
     }
 
     @GetMapping("/{trashcanId}")
-    public ApiResponse<TrashcanResponseDto> getTrashcanInfoById(@PathVariable Long trashcanId){
+    public ApiResponse<TrashcanWithImgResponseDto> getTrashcanInfo(@PathVariable Long trashcanId){
 
-        TrashcanResponseDto responseDto = trashcanService.getTrashcanInfo(trashcanId);
+        TrashcanWithImgResponseDto responseDto = trashcanService.getTrashcanInfo(trashcanId);
 
         return ApiResponse.ok(200, responseDto, "쓰레기통 조회 성공");
     }
-
 
     @PutMapping("/{trashcanId}")
     public ApiResponse<TrashcanResponseDto> updateProductInfo(@RequestBody @Valid UpdateTrashcanRequestDto requestDto, @PathVariable Long trashcanId){
         TrashcanResponseDto responseDto = trashcanService.updateTrashcanInfo(trashcanId, requestDto);
         return ApiResponse.ok(200, responseDto, "쓰레기통 정보 변경 성공");
     }
+
     @DeleteMapping("/{trashcanId}")
     public ApiResponse<?> deleteTrashcanInfo(@PathVariable Long trashcanId){
         trashcanService.deleteTrashcanInfo(trashcanId);

--- a/src/main/java/com/sscanner/team/trashcan/entity/TrashcanImg.java
+++ b/src/main/java/com/sscanner/team/trashcan/entity/TrashcanImg.java
@@ -1,23 +1,42 @@
 package com.sscanner.team.trashcan.entity;
 
 import com.sscanner.team.global.common.BaseEntity;
+import com.sscanner.team.trashcan.type.TrashCategory;
+import com.sscanner.team.trashcan.type.TrashcanStatus;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
+import java.math.BigDecimal;
+
+
+@SQLDelete(sql = "UPDATE trashcan_img SET deleted_at = CURRENT_TIMESTAMP WHERE trashcan_img_id = ?")
+@SQLRestriction("deleted_at is NULL")
+@NoArgsConstructor
 @Getter
 @Entity
 @Table(name = "Trashcan_img")
 public class TrashcanImg extends BaseEntity {
-    @Id
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "trashcan_img_id", nullable = false)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY, optional = false)
-    @JoinColumn(name = "trashcan_id", nullable = false)
-    private Trashcan trashcan;
+    @Column(name = "trashcan_id", nullable = false)
+    private Long trashcanId;
 
     @Column(name = "trashcan_img_url", nullable = false)
     private String trashcanImgUrl;
+
+    @Builder
+    public TrashcanImg(Long trashcanId, String trashcanImgUrl) {
+        this.trashcanId = trashcanId;
+        this.trashcanImgUrl = trashcanImgUrl;
+
+    }
 
 
 }

--- a/src/main/java/com/sscanner/team/trashcan/repository/TrashcanImgRepository.java
+++ b/src/main/java/com/sscanner/team/trashcan/repository/TrashcanImgRepository.java
@@ -1,0 +1,13 @@
+package com.sscanner.team.trashcan.repository;
+
+
+import com.sscanner.team.trashcan.entity.TrashcanImg;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface TrashcanImgRepository extends JpaRepository<TrashcanImg, Long> {
+    Optional<TrashcanImg> findByTrashcanId(Long trashcanId);
+}

--- a/src/main/java/com/sscanner/team/trashcan/responseDto/TrashcanWithImgResponseDto.java
+++ b/src/main/java/com/sscanner/team/trashcan/responseDto/TrashcanWithImgResponseDto.java
@@ -1,0 +1,35 @@
+package com.sscanner.team.trashcan.responseDto;
+
+import com.sscanner.team.trashcan.entity.Trashcan;
+import com.sscanner.team.trashcan.entity.TrashcanImg;
+import com.sscanner.team.trashcan.type.TrashCategory;
+import com.sscanner.team.trashcan.type.TrashcanStatus;
+
+import java.math.BigDecimal;
+
+public record TrashcanWithImgResponseDto(
+        Long id,
+        BigDecimal latitude,
+        BigDecimal longitude,
+        String roadNameAddress,
+        String detailedAddress,
+        TrashCategory trashCategory,
+        TrashcanStatus trashcanStatus,
+        String trashcanImgUrl
+
+
+) {
+
+    public static TrashcanWithImgResponseDto of(Trashcan trashcan, TrashcanImg trashcanImg) {
+        return new TrashcanWithImgResponseDto(
+                trashcan.getId(),
+                trashcan.getLatitude(),
+                trashcan.getLongitude(),
+                trashcan.getRoadNameAddress(),
+                trashcan.getDetailedAddress(),
+                trashcan.getTrashCategory(),
+                trashcan.getTrashcanStatus(),
+                trashcanImg.getTrashcanImgUrl()
+        );
+    }
+}

--- a/src/main/java/com/sscanner/team/trashcan/service/TrashcanImgService.java
+++ b/src/main/java/com/sscanner/team/trashcan/service/TrashcanImgService.java
@@ -1,0 +1,14 @@
+package com.sscanner.team.trashcan.service;
+
+import com.sscanner.team.trashcan.entity.TrashcanImg;
+import org.springframework.web.multipart.MultipartFile;
+
+public interface TrashcanImgService {
+
+    String uploadTrashcanImg(MultipartFile file);
+
+    TrashcanImg saveTrashcanImg(Long trashcanId, String imgUrl);
+
+    TrashcanImg getTrashcanImg(Long trashcanImgId);
+    void deleteTrashcanImg(Long trashcanImgId);
+}

--- a/src/main/java/com/sscanner/team/trashcan/service/TrashcanImgServiceImpl.java
+++ b/src/main/java/com/sscanner/team/trashcan/service/TrashcanImgServiceImpl.java
@@ -1,0 +1,102 @@
+package com.sscanner.team.trashcan.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.sscanner.team.trashcan.entity.TrashcanImg;
+import com.sscanner.team.trashcan.repository.TrashcanImgRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+
+@RequiredArgsConstructor
+@Service
+public class TrashcanImgServiceImpl implements TrashcanImgService {
+
+    @Value("${sscanner.bucket.base-url}")
+    private String baseUrl;
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+    private final AmazonS3 s3Client;
+
+    private final TrashcanImgRepository trashcanImgRepository;
+
+
+    @Override
+    public String uploadTrashcanImg(MultipartFile file) {
+
+        return uploadFile(file);
+    }
+
+    @Override
+    public TrashcanImg saveTrashcanImg(Long trashcanId, String imgUrl) {
+
+        TrashcanImg trashcanImg = new TrashcanImg(trashcanId, imgUrl);
+
+        return trashcanImgRepository.save(trashcanImg);
+    }
+
+    @Override
+    public TrashcanImg getTrashcanImg(Long trashcanId) {
+
+        return getTrashcanImgByTrashcanId(trashcanId);
+    }
+
+    private TrashcanImg getTrashcanImgByTrashcanId(Long trashcanId){
+        return trashcanImgRepository.findByTrashcanId(trashcanId)
+                .orElseThrow(null);
+    }
+
+    @Override
+    public void deleteTrashcanImg(Long trashcanImgId) {
+
+    }
+
+    // 여러개의 파일 업로드
+    public String uploadFile(MultipartFile file) {
+
+        String fileName = createFileName(file.getOriginalFilename());
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(file.getSize());
+        objectMetadata.setContentType(file.getContentType());
+
+        try(InputStream inputStream = file.getInputStream()) {
+            s3Client.putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMetadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
+        } catch(IOException e) {
+            throw new IllegalArgumentException("이미지 등록 실패");
+        }
+
+        return baseUrl + "/" + fileName;
+    }
+
+    // 파일명 중복 방지 (UUID)
+    private String createFileName(String fileName) {
+        return UUID.randomUUID().toString().concat(getFileExtension(fileName));
+    }
+
+    // 파일 유효성 검사
+    private String getFileExtension(String fileName) {
+        if (fileName.length() == 0) {
+            throw new IllegalArgumentException("File name cannot be empty");
+        }
+        ArrayList<String> fileValidate = new ArrayList<>();
+        fileValidate.add(".jpg");
+        fileValidate.add(".jpeg");
+        fileValidate.add(".png");
+        fileValidate.add(".JPG");
+        fileValidate.add(".JPEG");
+        fileValidate.add(".PNG");
+        String idxFileName = fileName.substring(fileName.lastIndexOf("."));
+        if (!fileValidate.contains(idxFileName)) {
+            throw new IllegalArgumentException("File extension is not valid");
+        }
+        return fileName.substring(fileName.lastIndexOf("."));
+    }
+}

--- a/src/main/java/com/sscanner/team/trashcan/service/TrashcanService.java
+++ b/src/main/java/com/sscanner/team/trashcan/service/TrashcanService.java
@@ -3,15 +3,23 @@ package com.sscanner.team.trashcan.service;
 import com.sscanner.team.trashcan.requestDto.RegisterTrashcanRequestDto;
 import com.sscanner.team.trashcan.requestDto.UpdateTrashcanRequestDto;
 import com.sscanner.team.trashcan.responseDto.TrashcanResponseDto;
+import com.sscanner.team.trashcan.responseDto.TrashcanWithImgResponseDto;
+import jakarta.transaction.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface TrashcanService {
 
-    TrashcanResponseDto registerTrashcan(RegisterTrashcanRequestDto requestDto);
-    TrashcanResponseDto getTrashcanInfo(Long trashcanId);
+
+    TrashcanWithImgResponseDto registerTrashcan(RegisterTrashcanRequestDto requestDto, MultipartFile file);
+    TrashcanWithImgResponseDto getTrashcanInfo(Long trashcanId);
+
+
     TrashcanResponseDto getNearByTrashcans();
     TrashcanResponseDto getNearByTrashcans2();
     TrashcanResponseDto getTrashcanByRoadAddress();
     void deleteTrashcanInfo(Long trashcanId);
 
     TrashcanResponseDto updateTrashcanInfo(Long trashcanId, UpdateTrashcanRequestDto requestDto);
+
+
 }

--- a/src/main/java/com/sscanner/team/trashcan/service/TrashcanServiceImpl.java
+++ b/src/main/java/com/sscanner/team/trashcan/service/TrashcanServiceImpl.java
@@ -2,13 +2,16 @@ package com.sscanner.team.trashcan.service;
 
 import com.sscanner.team.global.exception.BadRequestException;
 import com.sscanner.team.trashcan.entity.Trashcan;
+import com.sscanner.team.trashcan.entity.TrashcanImg;
 import com.sscanner.team.trashcan.repository.TrashcanRepository;
 import com.sscanner.team.trashcan.requestDto.RegisterTrashcanRequestDto;
 import com.sscanner.team.trashcan.requestDto.UpdateTrashcanRequestDto;
 import com.sscanner.team.trashcan.responseDto.TrashcanResponseDto;
+import com.sscanner.team.trashcan.responseDto.TrashcanWithImgResponseDto;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import static com.sscanner.team.global.exception.ExceptionCode.NOT_EXIST_TRASHCAN_ID;
 
@@ -17,24 +20,32 @@ import static com.sscanner.team.global.exception.ExceptionCode.NOT_EXIST_TRASHCA
 public class TrashcanServiceImpl implements TrashcanService {
 
     private final TrashcanRepository trashcanRepository;
+    private final TrashcanImgService trashcanImgService;
+
 
     @Override
     @Transactional
-    public TrashcanResponseDto registerTrashcan(RegisterTrashcanRequestDto requestDto) {
+    public TrashcanWithImgResponseDto registerTrashcan(RegisterTrashcanRequestDto requestDto, MultipartFile file) {
 
         Trashcan trashcan = requestDto.toEntity();
-
         trashcanRepository.save(trashcan);
 
-        return TrashcanResponseDto.from(trashcan);
+        String imgUrl = trashcanImgService.uploadTrashcanImg(file);
+
+        TrashcanImg trashcanImg = trashcanImgService.saveTrashcanImg(trashcan.getId(), imgUrl);
+
+        return TrashcanWithImgResponseDto.of(trashcan, trashcanImg);
     }
 
+
+
     @Override
-    public TrashcanResponseDto getTrashcanInfo(Long trashcanId) {
+    public TrashcanWithImgResponseDto getTrashcanInfo(Long trashcanId) {
 
         Trashcan trashcan = getTrashcanById(trashcanId);
+        TrashcanImg trashcanImg = trashcanImgService.getTrashcanImg(trashcanId);
 
-        return TrashcanResponseDto.from(trashcan);
+        return TrashcanWithImgResponseDto.of(trashcan, trashcanImg);
     }
 
     private Trashcan getTrashcanById(Long trashcanId) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,10 +21,32 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
       
-aws:
-  access-key: ${AWS_ACCESS_KEY}
-  secret-key: ${AWS_SECRET_KEY}
-  region.static: ${AWS_REGION}
+  servlet:
+    multipart:
+      enabled: true # 멀티파트 업로드 지원여부 (default: true)
+        #file-size-threshold: 0B # 파일을 디스크에 저장하지 않고 메모리에 저장하는 최소 크기 (default: 0B)
+        #location: /users/charming/temp # 업로드된 파일이 임시로 저장되는 디스크 위치 (default: WAS가 결정)
+      maxFileSize: 10MB
+      maxRequestSize: 30MB
+
+
+sscanner:
+  bucket:
+    base-url: ${BASE_URL}
+
+cloud:
+  aws:
+    s3:
+      bucket: ${BUCKET_NAME}
+    credentials:
+      accessKey: ${AWS_ACCESS_KEY}
+      secretKey: ${AWS_SECRET_KEY}
+    region:
+      static: ${AWS_REGION}
+      auto: false
+    stack:
+      auto: false
+
 
 logging:
   level:


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->
resolved : #22  <!-- 관련된 이슈를 적어주세요 #이슈번호 -->
## 📌 쓰레기통 이미지 등록과 조회 기능 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

## 👩‍💻 쓰레기통 등록시 이미지가 같이 등록, 조회시 이미지 url을 같이 조회

- 기존 TrashcanApiController의 생성, 조회 엔드포인트 수정
- TrashcanService에 이미지 등록, 조회 로직을 추가 했으며 TrashcanImgService를 주입받아 이미지 관련 기능을 이용하도록 했습니다.
- s3 bucket 관련 상수들을 yml 파일의 환경변수로 옮겼으며 환경변수는 시스템 실행후 값을 받아오는 방식이므로 상수가 아닌 일반 변수로 바꿔주었습니다 ex) BASE_URL -> baseUrl
- yml 파일에 cloud 관련 항목을 만들어 하위 항목에 s3 관련 설정을 추가했습니다
- yml 파일에 multipart 관련 설정을 추가했습니다. 파일 하나의 최대크기, 요청 한번당 총 크기 제한등의 설정입니다.
- 파일 업로드 관련 예외처리 코드 추가
- 쓰레기통 정보, 이미지 url을 같이 반환하는 dto 추가


## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

기존 로직에 이미지 관련 기능이 추가적으로 들어간거라 실수가 있는 부분들이 있을거 같습니다
어색한 부분이 있다면 말씀해주시면 감사하겠습니다.

게시판 이미지와 업로드 부분을 공유하려 했으나 아직 통합을 못한 상태로
쓰레기통 이미지의 경우 TrashcanImgServiceImpl에 s3로 업로드 하는 메서드들이 들어가 있습니다.
해당 부분은 추후에 분리, 통합을 하도록 하겠습니다.

s3Config의 경우는 게시판과 공유중인데 네이밍을 일부 수정했습니다.
게시판 로직에 영향이 가지 않도록 신경썻으나 실수가 있을지 모르니 한번씩 확인해주시면 감사하겠습니다.  