### PR TITLE
Feature/34 주변 쓰레기통 조회 API 구현

### DIFF
--- a/src/main/java/com/sscanner/team/global/exception/ExceptionCode.java
+++ b/src/main/java/com/sscanner/team/global/exception/ExceptionCode.java
@@ -49,7 +49,8 @@ public enum ExceptionCode {
     DUPLICATED_PHONE(409, "이미 가입된 핸드폰 번호입니다. "),
     PASSWORD_NOT_MATCH(400, "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
     USER_NOT_FOUND(400,"해당 유저가 존재하지 않습니다."),
-    NOT_EXIST_TRASHCAN_IMG_ID(400, "해당하는 쓰레기통 이미지가 존재하지 않습니다.");
+    NOT_EXIST_TRASHCAN_IMG_ID(400, "해당하는 쓰레기통 이미지가 존재하지 않습니다."),
+    NOT_FOUND_NEARBY_TRASHCANS(404, "근처에 쓰레기통이 존재하지 않습니다.");
 
     private final int code;
     private final String message;

--- a/src/main/java/com/sscanner/team/global/utils/GeoUtils.java
+++ b/src/main/java/com/sscanner/team/global/utils/GeoUtils.java
@@ -1,0 +1,28 @@
+package com.sscanner.team.global.utils;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+
+public class GeoUtils {
+
+    private static final BigDecimal EARTH_RADIUS = new BigDecimal("6371"); // 지구 반지름
+    private static final int SCALE = 8; // 최대 소수점 자리수
+
+    // 반경을 기반으로 최소/최대 위도 및 경도 범위 계산
+    // 사각형 범위의 데이터를 검색 가로, 세로 길이로 사각형을 만드는 것과 같음
+    public static BigDecimal[] getBoundingBox(BigDecimal lat, BigDecimal lon, double radius) {
+
+        // 위도 범위 계산
+        BigDecimal latChange = BigDecimal.valueOf(radius / 1000).divide(EARTH_RADIUS, SCALE, RoundingMode.HALF_UP);
+        BigDecimal minLat = lat.subtract(BigDecimal.valueOf(Math.toDegrees(latChange.doubleValue())));
+        BigDecimal maxLat = lat.add(BigDecimal.valueOf(Math.toDegrees(latChange.doubleValue())));
+
+        // 경도 범위 계산
+        BigDecimal cosLat = BigDecimal.valueOf(Math.cos(Math.toRadians(lat.doubleValue())));
+        BigDecimal lonChange = BigDecimal.valueOf(radius / 1000).divide(EARTH_RADIUS.multiply(cosLat), SCALE, RoundingMode.HALF_UP);
+        BigDecimal minLon = lon.subtract(BigDecimal.valueOf(Math.toDegrees(lonChange.doubleValue())));
+        BigDecimal maxLon = lon.add(BigDecimal.valueOf(Math.toDegrees(lonChange.doubleValue())));
+
+        return new BigDecimal[]{minLat, maxLat, minLon, maxLon};
+    }
+}

--- a/src/main/java/com/sscanner/team/trashcan/controller/TrashcanApiController.java
+++ b/src/main/java/com/sscanner/team/trashcan/controller/TrashcanApiController.java
@@ -9,10 +9,16 @@ import com.sscanner.team.trashcan.responseDto.TrashcanWithImgResponseDto;
 import com.sscanner.team.trashcan.service.TrashcanImgService;
 import com.sscanner.team.trashcan.service.TrashcanService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.math.BigDecimal;
+import java.util.List;
 
 
 @RequiredArgsConstructor
@@ -37,6 +43,22 @@ public class TrashcanApiController {
         TrashcanWithImgResponseDto responseDto = trashcanService.getTrashcanInfo(trashcanId);
 
         return ApiResponse.ok(200, responseDto, "쓰레기통 조회 성공");
+    }
+
+    @GetMapping("/getNearByTrashcans")
+    public ApiResponse<List<TrashcanResponseDto>> getNearByTrashcan(@NotNull(message = "위도는 필수입니다.")
+                                                                         @DecimalMin(value = "-90.0", message = "위도는 -90 이상이어야 합니다.")
+                                                                         @DecimalMax(value = "90.0", message = "위도는 90 이하이어야 합니다.")
+                                                                         @RequestParam BigDecimal latitude,
+
+                                                                     @NotNull(message = "경도는 필수입니다.")
+                                                                         @DecimalMin(value = "-180.0", message = "경도는 -180 이상이어야 합니다.")
+                                                                         @DecimalMax(value = "180.0", message = "경도는 180 이하이어야 합니다.")
+                                                                         @RequestParam BigDecimal longitude){
+
+        List<TrashcanResponseDto> responseDtos = trashcanService.getTrashcanByCoordinate(latitude, longitude);
+
+        return ApiResponse.ok(200, responseDtos, "쓰레기통 조회 성공");
     }
 
     @PutMapping("/{trashcanId}")

--- a/src/main/java/com/sscanner/team/trashcan/repository/TrashcanRepository.java
+++ b/src/main/java/com/sscanner/team/trashcan/repository/TrashcanRepository.java
@@ -2,8 +2,23 @@ package com.sscanner.team.trashcan.repository;
 
 import com.sscanner.team.trashcan.entity.Trashcan;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface TrashcanRepository extends JpaRepository<Trashcan, Long> {
+
+    //위도, 경도로 사각형 범위를 설정해 포함되는 값을 반환해주는 쿼리
+    @Query("SELECT t FROM Trashcan t WHERE t.latitude BETWEEN :minLat AND :maxLat AND t.longitude BETWEEN :minLon AND :maxLon")
+    Optional<List<Trashcan>> findTrashcansWithinBoundingBox(
+            @Param("minLat") BigDecimal minLat,
+            @Param("maxLat") BigDecimal maxLat,
+            @Param("minLon") BigDecimal minLon,
+            @Param("maxLon") BigDecimal maxLon
+    );
 }

--- a/src/main/java/com/sscanner/team/trashcan/service/TrashcanService.java
+++ b/src/main/java/com/sscanner/team/trashcan/service/TrashcanService.java
@@ -7,6 +7,9 @@ import com.sscanner.team.trashcan.responseDto.TrashcanWithImgResponseDto;
 import jakarta.transaction.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.math.BigDecimal;
+import java.util.List;
+
 public interface TrashcanService {
 
 
@@ -22,4 +25,5 @@ public interface TrashcanService {
     TrashcanResponseDto updateTrashcanInfo(Long trashcanId, UpdateTrashcanRequestDto requestDto);
 
 
+    List<TrashcanResponseDto> getTrashcanByCoordinate(BigDecimal latitude, BigDecimal longitude);
 }

--- a/src/main/java/com/sscanner/team/trashcan/service/TrashcanServiceImpl.java
+++ b/src/main/java/com/sscanner/team/trashcan/service/TrashcanServiceImpl.java
@@ -71,8 +71,12 @@ public class TrashcanServiceImpl implements TrashcanService {
 
     @Transactional
     public void deleteTrashcanInfo(Long trashcanId) {
-        Trashcan trashcan = getTrashcanById(trashcanId);
-        trashcanRepository.delete(trashcan);
+
+        try {
+            trashcanRepository.deleteById(trashcanId);
+        } catch (IllegalArgumentException e){
+            throw new BadRequestException(NOT_EXIST_TRASHCAN_ID);
+        }
     }
 
     @Transactional

--- a/src/main/java/com/sscanner/team/trashcan/service/TrashcanServiceImpl.java
+++ b/src/main/java/com/sscanner/team/trashcan/service/TrashcanServiceImpl.java
@@ -1,6 +1,7 @@
 package com.sscanner.team.trashcan.service;
 
 import com.sscanner.team.global.exception.BadRequestException;
+import com.sscanner.team.global.utils.GeoUtils;
 import com.sscanner.team.trashcan.entity.Trashcan;
 import com.sscanner.team.trashcan.entity.TrashcanImg;
 import com.sscanner.team.trashcan.repository.TrashcanRepository;
@@ -13,11 +14,19 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
 import static com.sscanner.team.global.exception.ExceptionCode.NOT_EXIST_TRASHCAN_ID;
+import static com.sscanner.team.global.exception.ExceptionCode.NOT_FOUND_NEARBY_TRASHCANS;
 
 @RequiredArgsConstructor
 @Service
 public class TrashcanServiceImpl implements TrashcanService {
+
+    //쓰레기통 위도, 경도 검색 범위 설정 미터단위
+    private static final double RADIUS_FOR_SEARCH_METERS = 200.0;
 
     private final TrashcanRepository trashcanRepository;
     private final TrashcanImgService trashcanImgService;
@@ -31,7 +40,6 @@ public class TrashcanServiceImpl implements TrashcanService {
         trashcanRepository.save(trashcan);
 
         String imgUrl = trashcanImgService.uploadTrashcanImg(file);
-
         TrashcanImg trashcanImg = trashcanImgService.saveTrashcanImg(trashcan.getId(), imgUrl);
 
         return TrashcanWithImgResponseDto.of(trashcan, trashcanImg);
@@ -54,7 +62,36 @@ public class TrashcanServiceImpl implements TrashcanService {
     }
 
     @Override
+    public List<TrashcanResponseDto> getTrashcanByCoordinate(BigDecimal latitude, BigDecimal longitude) {
+
+        BigDecimal[] boundingBox = GeoUtils.getBoundingBox(latitude, longitude, RADIUS_FOR_SEARCH_METERS);
+
+        BigDecimal minLat = boundingBox[0];
+        BigDecimal maxLat = boundingBox[1];
+        BigDecimal minLon = boundingBox[2];
+        BigDecimal maxLon = boundingBox[3];
+
+        List<Trashcan> trashcans = getTrashcansByLatAndLon(minLat, maxLat, minLon, maxLon);
+
+        return convertToTrashcanResponses(trashcans);
+    }
+
+    private List<Trashcan> getTrashcansByLatAndLon(BigDecimal minLat, BigDecimal maxLat, BigDecimal minLon, BigDecimal maxLon) {
+        return trashcanRepository.findTrashcansWithinBoundingBox(minLat, maxLat, minLon, maxLon)
+                .orElseThrow(() -> new BadRequestException(NOT_FOUND_NEARBY_TRASHCANS));
+    }
+
+    private static List<TrashcanResponseDto> convertToTrashcanResponses(List<Trashcan> trashcans) {
+        List<TrashcanResponseDto> trashcanResponseDtos = new ArrayList<>();
+        for (Trashcan trashcan : trashcans) {
+            trashcanResponseDtos.add(TrashcanResponseDto.from(trashcan));
+        }
+        return trashcanResponseDtos;
+    }
+
+    @Override
     public TrashcanResponseDto getNearByTrashcans() {
+
         return null;
     }
 
@@ -85,6 +122,5 @@ public class TrashcanServiceImpl implements TrashcanService {
         trashcan.updateInfo(requestDto);
         return TrashcanResponseDto.from(trashcan);
     }
-
 
 }


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->
resolved : #34  <!-- 관련된 이슈를 적어주세요 #이슈번호 -->
## 📌 과제 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->
위도, 경도를 기반으로 주변 200미터 범위의 쓰레기통 검색기능

## 👩‍💻 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->
- 위도, 경도를 이용해 사각형 범위를 설정하고 그 안에 포함되는 데이터를 반환하도록 했습니다.
- 위도, 경도 계산의 책임은 TrashcanService의 책임이 아니라고 생각하여 별도의 GeoUtils라는 클래스로 분리하였습니다.
- 조회 로직에 대한 엔드포인트와 예외 코드를 추가하였습니다.
- TrasncanDelete의 로직을 수정했습니다. find 메서드를 제거하고 deleteById에 try catch문을 적용해
   데이터가 없을시 곧바로 예외를 발생시키도록 수정했습니다. 
   데이터베이스 접촉횟수가 1회로 감소하는 효과가 있습니다.

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->

## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
예외 코드가 올바른지, 그리고 global에 utils 디렉토리를 추가하고 GeoUtils를 넣었는데 구조상 올바른지에 대해
의견을 여쭤보고 싶습니다.
그 외에도 의견 자유롭게 공유해주시면 감사하겠습니다!
