### PR TITLE
Feature/42 ci 파이프라인에 sonarqube 도입

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI Pipeline
 on:
   push:
     branches:
-      [ develop, feature/42-ci-파이프라인에-sonarqube-도입 ]
+      [ develop ]
   pull_request:
     branches:
       [ develop ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,12 @@ name: CI Pipeline
 on:
   push:
     branches:
-      [ develop ]
+      [ develop, feature/42-ci-파이프라인에-sonarqube-도입 ]
   pull_request:
     branches:
       [ develop ]
+    types:
+      [opened, synchronize, reopened]
 
 jobs:
   Continuous-Integration:
@@ -32,6 +34,8 @@ jobs:
     steps:
       - name: Github Repository 파일 불러오기
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # 모든 커밋히스토리를 불러옴
 
       - name: JDK 17 버전 설치
         uses: actions/setup-java@v4
@@ -43,6 +47,13 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '20'
+
+      - name: SonarCloud 패키지 캐싱
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
 
       - name: Gradle 캐싱
         uses: actions/cache@v3
@@ -59,4 +70,10 @@ jobs:
         shell: bash
 
       - name: 빌드 및 테스트
-        run: ./gradlew clean build
+        run: ./gradlew build
+
+      - name: Sonarqube 분석
+        env:
+          GITHUB_TOKEN: ${{ secrets.GIT_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew sonar --info

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,15 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.4'
     id 'io.spring.dependency-management' version '1.1.6'
+    id "org.sonarqube" version "4.4.1.3373"
+}
+
+sonar {
+    properties {
+        property "sonar.projectKey", "prgrms-be-devcourse_NBE1_2_Team03"
+        property "sonar.organization", "prgrms-be-devcourse"
+        property "sonar.host.url", "https://sonarcloud.io"
+    }
 }
 
 group = 'com.sscanner'

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,21 @@ plugins {
     id 'org.springframework.boot' version '3.3.4'
     id 'io.spring.dependency-management' version '1.1.6'
     id "org.sonarqube" version "4.4.1.3373"
+    id "jacoco"
+}
+
+def jacocoDir = layout.buildDirectory.dir("reports/")
+jacocoTestReport {
+    dependsOn test	// 테스트가 수행되어야만 report를 생성할 수 있도록 설정
+    reports {
+        html.required.set(true)
+        xml.required.set(true)
+        csv.required.set(true)
+        html.destination jacocoDir.get().file("jacoco/index.html").asFile
+        xml.destination jacocoDir.get().file("jacoco/index.xml").asFile
+        csv.destination jacocoDir.get().file("jacoco/index.csv").asFile
+    }
+
 }
 
 sonar {
@@ -62,4 +77,5 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
 }


### PR DESCRIPTION

resolved : #42 
## 📌 과제 설명
CI 파이프라인에 sonar를 도입했습니다.

## 👩‍💻 요구 사항과 구현 내용 
- gradle에 sonar 플러그인 및 Properties를 추가하였습니다.
- gradle에 jacoco 플러그인 및 Properties를 추가하였습니다.
- CI 파이프라인에 sonar로 코드 분석하는 부분을 추가하였습니다. 
- Develop 브랜치로 PR, Push시 분석이 이루어지게 하였습니다.
- PR시 분석결과는 sonarcloud봇과 연동돼 함께 받아보실 수 있고 해당 링크로 더 자세한 내용을 받아보실 수 있습니다.
![image](https://github.com/user-attachments/assets/25fd5c59-9e56-4a6d-9503-bae7c336dc47)
![image](https://github.com/user-attachments/assets/dbf8a8a9-b713-4392-b2d2-706403f83608)
<br><br>
- Sonar Cloud에 Jacoco라는 Test Coverage측정 Tool을 연동해 작성하신 테스트가 현재 코드를 얼마나 커버하고 있는지를 확인하실 수 있습니다.
![image](https://github.com/user-attachments/assets/765cf88f-2a57-438d-a871-c93b3cb8fec5)


## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
- 자세한 내용은 내일 RBF때 말씀드리도록 하겠습니다!
