### PR TITLE
Refactor/56 board comment api

### DIFF
--- a/src/main/java/com/sscanner/team/board/controller/BoardController.java
+++ b/src/main/java/com/sscanner/team/board/controller/BoardController.java
@@ -3,6 +3,7 @@ package com.sscanner.team.board.controller;
 import com.sscanner.team.board.requestdto.BoardCreateRequestDTO;
 import com.sscanner.team.board.requestdto.BoardUpdateRequestDTO;
 import com.sscanner.team.board.responsedto.BoardListResponseDTO;
+import com.sscanner.team.board.responsedto.BoardLocationInfoResponseDTO;
 import com.sscanner.team.board.responsedto.BoardResponseDTO;
 import com.sscanner.team.board.service.BoardService;
 import com.sscanner.team.board.type.BoardCategory;
@@ -62,5 +63,13 @@ public class BoardController {
         BoardResponseDTO boardDetailed = boardService.getBoardDetailed(boardId);
 
         return ApiResponse.ok(200, boardDetailed, "게시판 상세 정보 조회 완료!!");
+        return ApiResponse.ok(200, boardDetailed, "신고 게시글 상세 정보 조회 완료!!");
+    }
+
+    @GetMapping("/location/{boardId}")
+    public ApiResponse<BoardLocationInfoResponseDTO> readBoardLocationInfo(@PathVariable Long boardId) {
+        BoardLocationInfoResponseDTO boardLocationInfo = boardService.getBoardLocationInfo(boardId);
+
+        return ApiResponse.ok(200, boardLocationInfo, "신고 게시글 위치 정보 조회 완료!!");
     }
 }

--- a/src/main/java/com/sscanner/team/board/controller/BoardController.java
+++ b/src/main/java/com/sscanner/team/board/controller/BoardController.java
@@ -35,7 +35,7 @@ public class BoardController {
     public ApiResponse<?> deleteBoard(@PathVariable Long boardId) {
         boardService.deleteBoard(boardId);
 
-        return ApiResponse.ok(200, "게시판 삭제 완료!!");
+        return ApiResponse.ok(200, "신고 게시글 삭제 완료!!");
     }
 
     @PatchMapping("/{boardId}")

--- a/src/main/java/com/sscanner/team/board/controller/BoardController.java
+++ b/src/main/java/com/sscanner/team/board/controller/BoardController.java
@@ -62,7 +62,6 @@ public class BoardController {
     public ApiResponse<BoardResponseDTO> readBoard(@PathVariable Long boardId) {
         BoardResponseDTO boardDetailed = boardService.getBoardDetailed(boardId);
 
-        return ApiResponse.ok(200, boardDetailed, "게시판 상세 정보 조회 완료!!");
         return ApiResponse.ok(200, boardDetailed, "신고 게시글 상세 정보 조회 완료!!");
     }
 

--- a/src/main/java/com/sscanner/team/board/controller/BoardController.java
+++ b/src/main/java/com/sscanner/team/board/controller/BoardController.java
@@ -42,9 +42,11 @@ public class BoardController {
     public ApiResponse<BoardResponseDTO> updateBoard(@PathVariable Long boardId,
                                      @Valid @RequestPart(value = "data") BoardUpdateRequestDTO boardUpdateRequestDTO,
                                      @RequestPart(value = "files", required = false) List<MultipartFile> files) {
+                                                     @Valid @RequestPart(value = "data") BoardUpdateRequestDTO boardUpdateRequestDTO,
+                                                     @RequestPart(value = "files", required = false) List<MultipartFile> files) {
         BoardResponseDTO board = boardService.updateBoard(boardId, boardUpdateRequestDTO, files);
 
-        return ApiResponse.ok(200, board, "게시판 수정 완료!!");
+        return ApiResponse.ok(200, board, "신고 게시글 수정 완료!!");
     }
 
     @GetMapping()

--- a/src/main/java/com/sscanner/team/board/controller/BoardController.java
+++ b/src/main/java/com/sscanner/team/board/controller/BoardController.java
@@ -23,12 +23,12 @@ public class BoardController {
 
     private final BoardService boardService;
 
-    @PostMapping()
+    @PostMapping
     public ApiResponse<BoardResponseDTO> createAddBoard(@Valid @RequestPart(value = "data") BoardCreateRequestDTO boardCreateRequestDTO,
                                                         @RequestPart(value = "files") List<MultipartFile> files) {
         BoardResponseDTO board = boardService.createBoard(boardCreateRequestDTO, files);
 
-        return ApiResponse.ok(201, board, "쓰레기통 신고 게시글 저장 완료!!");
+        return ApiResponse.ok(201, board, "신고 게시글 저장 완료!!");
     }
 
     @DeleteMapping("/{boardId}")

--- a/src/main/java/com/sscanner/team/board/controller/BoardController.java
+++ b/src/main/java/com/sscanner/team/board/controller/BoardController.java
@@ -10,7 +10,6 @@ import com.sscanner.team.global.common.response.ApiResponse;
 import com.sscanner.team.trashcan.type.TrashCategory;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -40,8 +39,6 @@ public class BoardController {
 
     @PatchMapping("/{boardId}")
     public ApiResponse<BoardResponseDTO> updateBoard(@PathVariable Long boardId,
-                                     @Valid @RequestPart(value = "data") BoardUpdateRequestDTO boardUpdateRequestDTO,
-                                     @RequestPart(value = "files", required = false) List<MultipartFile> files) {
                                                      @Valid @RequestPart(value = "data") BoardUpdateRequestDTO boardUpdateRequestDTO,
                                                      @RequestPart(value = "files", required = false) List<MultipartFile> files) {
         BoardResponseDTO board = boardService.updateBoard(boardId, boardUpdateRequestDTO, files);
@@ -49,15 +46,15 @@ public class BoardController {
         return ApiResponse.ok(200, board, "신고 게시글 수정 완료!!");
     }
 
-    @GetMapping()
-    public ApiResponse<Page<BoardListResponseDTO>> readAllBoards(
+    @GetMapping
+    public ApiResponse<BoardListResponseDTO> readAllBoards(
             @RequestParam(value = "board_category", defaultValue = "MODIFY") BoardCategory boardCategory,
             @RequestParam(value = "trash_category", defaultValue = "NORMAL") TrashCategory trashCategory,
             @RequestParam(value = "page", defaultValue = "0") Integer page,
             @RequestParam(value = "size", defaultValue = "10") Integer size){
-        Page<BoardListResponseDTO> boards = boardService.getBoardList(boardCategory, trashCategory, page, size);
+        BoardListResponseDTO result = boardService.getBoardList(boardCategory, trashCategory, page, size);
 
-        return ApiResponse.ok(200, boards, "게시판 목록 조회 완료!!");
+        return ApiResponse.ok(200, result, "신고 게시글 목록 조회 완료!!");
     }
 
     @GetMapping("/{boardId}")

--- a/src/main/java/com/sscanner/team/board/entity/Board.java
+++ b/src/main/java/com/sscanner/team/board/entity/Board.java
@@ -2,6 +2,7 @@ package com.sscanner.team.board.entity;
 
 import com.sscanner.team.User;
 import com.sscanner.team.board.requestdto.BoardUpdateRequestDTO;
+import com.sscanner.team.board.type.ApprovalStatus;
 import com.sscanner.team.board.type.BoardCategory;
 import com.sscanner.team.global.common.BaseEntity;
 import com.sscanner.team.trashcan.type.TrashCategory;
@@ -39,8 +40,9 @@ public class Board extends BaseEntity {
     @Column(name = "significants")
     private String significant;
 
-    @Column(name = "give_point", nullable = false)
-    private Boolean givePoint;
+    @Column(name = "approval_status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ApprovalStatus approvalStatus;
 
     @Column(name = "trashcan_id")
     private Long trashcanId;
@@ -79,7 +81,7 @@ public class Board extends BaseEntity {
         this.user = user;
         this.boardCategory = boardCategory;
         this.significant = significant;
-        this.givePoint = false;
+        this.approvalStatus = ApprovalStatus.REVIEWING;
         this.trashcanId = trashcanId;
         this.latitude = latitude;
         this.longitude = longitude;

--- a/src/main/java/com/sscanner/team/board/repository/BoardRepository.java
+++ b/src/main/java/com/sscanner/team/board/repository/BoardRepository.java
@@ -14,10 +14,4 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     Page<Board> findAllByCategories(@Param("boardCategory") BoardCategory boardCategory,
                                                        @Param("trashCategory")TrashCategory trashCategory,
                                                        Pageable pageable);
-
-    @Query("select b from Board b where b.approvalStatus = :approvalStatus and b.boardCategory = :boardCategory and b.trashCategory = :trashCategory")
-    Page<Board> findAllByStatusAndCategories(@Param("approvalStatus") ApprovalStatus approvalStatus,
-                                           @Param("boardCategory") BoardCategory boardCategory,
-                                           @Param("trashCategory")TrashCategory trashCategory,
-                                           Pageable pageable);
 }

--- a/src/main/java/com/sscanner/team/board/repository/BoardRepository.java
+++ b/src/main/java/com/sscanner/team/board/repository/BoardRepository.java
@@ -11,7 +11,13 @@ import org.springframework.data.repository.query.Param;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
     @Query("select b from Board b where b.boardCategory = :boardCategory and b.trashCategory = :trashCategory")
-    Page<Board> findAllByBoardCategoryAndTrashCategory(@Param("boardCategory") BoardCategory boardCategory,
+    Page<Board> findAllByCategories(@Param("boardCategory") BoardCategory boardCategory,
                                                        @Param("trashCategory")TrashCategory trashCategory,
                                                        Pageable pageable);
+
+    @Query("select b from Board b where b.approvalStatus = :approvalStatus and b.boardCategory = :boardCategory and b.trashCategory = :trashCategory")
+    Page<Board> findAllByStatusAndCategories(@Param("approvalStatus") ApprovalStatus approvalStatus,
+                                           @Param("boardCategory") BoardCategory boardCategory,
+                                           @Param("trashCategory")TrashCategory trashCategory,
+                                           Pageable pageable);
 }

--- a/src/main/java/com/sscanner/team/board/requestdto/BoardCreateRequestDTO.java
+++ b/src/main/java/com/sscanner/team/board/requestdto/BoardCreateRequestDTO.java
@@ -10,9 +10,6 @@ import jakarta.validation.constraints.*;
 import java.math.BigDecimal;
 
 public record BoardCreateRequestDTO(
-        @NotNull(message = "userId는 필수입니다.")
-        String userId,
-
         @NotNull(message = "게시판 유형 작성은 필수입니다.")
         BoardCategory boardCategory,
 
@@ -42,7 +39,7 @@ public record BoardCreateRequestDTO(
         @NotNull(message = "쓰레기통 상태 작성은 필수입니다.")
         TrashcanStatus updatedTrashcanStatus
 ) {
-        public Board toEntityAddBoard(User user) {
+        public Board toEntityBoard(User user) {
                 return Board.builder()
                         .user(user)
                         .boardCategory(this.boardCategory())

--- a/src/main/java/com/sscanner/team/board/requestdto/BoardUpdateRequestDTO.java
+++ b/src/main/java/com/sscanner/team/board/requestdto/BoardUpdateRequestDTO.java
@@ -10,9 +10,6 @@ import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 
 public record BoardUpdateRequestDTO(
-        @NotNull(message = "userId는 필수입니다.")
-        String userId,
-
         String significant,
 
         Long trashcanId,

--- a/src/main/java/com/sscanner/team/board/responsedto/BoardInfoResponseDTO.java
+++ b/src/main/java/com/sscanner/team/board/responsedto/BoardInfoResponseDTO.java
@@ -1,0 +1,19 @@
+package com.sscanner.team.board.responsedto;
+
+import com.sscanner.team.board.entity.Board;
+
+public record BoardInfoResponseDTO(
+        Long id,
+        String boardFirstImgUrl,
+        String roadNameAddress,
+        String detailedAddress
+) {
+    public static BoardInfoResponseDTO of(Board board, String boardFirstImgUrl) {
+        return new BoardInfoResponseDTO(
+                board.getId(),
+                boardFirstImgUrl,
+                board.getRoadNameAddress(),
+                board.getDetailedAddress()
+        );
+    }
+}

--- a/src/main/java/com/sscanner/team/board/responsedto/BoardListResponseDTO.java
+++ b/src/main/java/com/sscanner/team/board/responsedto/BoardListResponseDTO.java
@@ -1,23 +1,21 @@
 package com.sscanner.team.board.responsedto;
 
-import com.sscanner.team.board.entity.Board;
 import com.sscanner.team.board.type.BoardCategory;
 import com.sscanner.team.trashcan.type.TrashCategory;
+import org.springframework.data.domain.Page;
 
 public record BoardListResponseDTO(
-        Long id,
         BoardCategory boardCategory,
-        String roadNameAddress,
-        String detailedAddress,
-        TrashCategory trashCategory
+        TrashCategory trashCategory,
+        Page<BoardInfoResponseDTO> boardList
 ) {
-    public static BoardListResponseDTO from(Board board) {
+    public static BoardListResponseDTO from(BoardCategory boardCategory,
+                                            TrashCategory trashCategory,
+                                            Page<BoardInfoResponseDTO> boardList) {
         return new BoardListResponseDTO(
-                board.getId(),
-                board.getBoardCategory(),
-                board.getRoadNameAddress(),
-                board.getDetailedAddress(),
-                board.getTrashCategory()
+                boardCategory,
+                trashCategory,
+                boardList
         );
     }
 }

--- a/src/main/java/com/sscanner/team/board/responsedto/BoardLocationInfoResponseDTO.java
+++ b/src/main/java/com/sscanner/team/board/responsedto/BoardLocationInfoResponseDTO.java
@@ -1,0 +1,26 @@
+package com.sscanner.team.board.responsedto;
+
+import com.sscanner.team.board.entity.Board;
+import com.sscanner.team.trashcan.type.TrashCategory;
+
+import java.math.BigDecimal;
+
+public record BoardLocationInfoResponseDTO(
+        Long id,
+        TrashCategory trashCategory,
+        BigDecimal latitude,
+        BigDecimal longitude,
+        String roadNameAddress,
+        String detailedAddress
+) {
+    public static BoardLocationInfoResponseDTO from(Board board) {
+        return new BoardLocationInfoResponseDTO(
+                board.getId(),
+                board.getTrashCategory(),
+                board.getLatitude(),
+                board.getLongitude(),
+                board.getRoadNameAddress(),
+                board.getDetailedAddress()
+        );
+    }
+}

--- a/src/main/java/com/sscanner/team/board/responsedto/BoardResponseDTO.java
+++ b/src/main/java/com/sscanner/team/board/responsedto/BoardResponseDTO.java
@@ -6,7 +6,6 @@ import com.sscanner.team.board.type.BoardCategory;
 import com.sscanner.team.trashcan.type.TrashCategory;
 import com.sscanner.team.trashcan.type.TrashcanStatus;
 
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -15,10 +14,6 @@ public record BoardResponseDTO(
     BoardCategory boardCategory,
     String significant,
     Long trashcanId,
-    BigDecimal latitude,
-    BigDecimal longitude,
-    String roadNameAddress,
-    String detailedAddress,
     TrashCategory trashCategory,
     TrashcanStatus updatedTrashcanStatus,
     List<BoardImgResponseDTO> boardImgs
@@ -29,10 +24,6 @@ public record BoardResponseDTO(
                 board.getBoardCategory(),
                 board.getSignificant(),
                 board.getTrashcanId(),
-                board.getLatitude(),
-                board.getLongitude(),
-                board.getRoadNameAddress(),
-                board.getDetailedAddress(),
                 board.getTrashCategory(),
                 board.getUpdatedTrashcanStatus(),
                 boardImgs.stream()

--- a/src/main/java/com/sscanner/team/board/service/BoardImgServiceImpl.java
+++ b/src/main/java/com/sscanner/team/board/service/BoardImgServiceImpl.java
@@ -4,7 +4,6 @@ import com.sscanner.team.board.entity.BoardImg;
 import com.sscanner.team.board.repository.BoardImgRepository;
 import com.sscanner.team.global.common.service.ImageService;
 import com.sscanner.team.global.exception.BadRequestException;
-import com.sscanner.team.global.exception.ExceptionCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/sscanner/team/board/service/BoardService.java
+++ b/src/main/java/com/sscanner/team/board/service/BoardService.java
@@ -1,5 +1,6 @@
 package com.sscanner.team.board.service;
 
+import com.sscanner.team.admin.responsedto.AdminBoardInfoResponseDTO;
 import com.sscanner.team.board.entity.Board;
 import com.sscanner.team.board.requestdto.BoardCreateRequestDTO;
 import com.sscanner.team.board.requestdto.BoardUpdateRequestDTO;
@@ -23,6 +24,6 @@ public interface BoardService {
     BoardListResponseDTO getBoardList(BoardCategory boardCategory, TrashCategory trashCategory,
                                          Integer page, Integer size);
     BoardResponseDTO getBoardDetailed(Long boardId);
-
+    BoardLocationInfoResponseDTO getBoardLocationInfo(Long boardId);
     Board getBoard(Long boardId);
 }

--- a/src/main/java/com/sscanner/team/board/service/BoardService.java
+++ b/src/main/java/com/sscanner/team/board/service/BoardService.java
@@ -1,6 +1,5 @@
 package com.sscanner.team.board.service;
 
-import com.sscanner.team.admin.responsedto.AdminBoardInfoResponseDTO;
 import com.sscanner.team.board.entity.Board;
 import com.sscanner.team.board.requestdto.BoardCreateRequestDTO;
 import com.sscanner.team.board.requestdto.BoardUpdateRequestDTO;
@@ -9,7 +8,6 @@ import com.sscanner.team.board.responsedto.BoardLocationInfoResponseDTO;
 import com.sscanner.team.board.responsedto.BoardResponseDTO;
 import com.sscanner.team.board.type.BoardCategory;
 import com.sscanner.team.trashcan.type.TrashCategory;
-import org.springframework.data.domain.Page;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;

--- a/src/main/java/com/sscanner/team/board/service/BoardService.java
+++ b/src/main/java/com/sscanner/team/board/service/BoardService.java
@@ -4,6 +4,7 @@ import com.sscanner.team.board.entity.Board;
 import com.sscanner.team.board.requestdto.BoardCreateRequestDTO;
 import com.sscanner.team.board.requestdto.BoardUpdateRequestDTO;
 import com.sscanner.team.board.responsedto.BoardListResponseDTO;
+import com.sscanner.team.board.responsedto.BoardLocationInfoResponseDTO;
 import com.sscanner.team.board.responsedto.BoardResponseDTO;
 import com.sscanner.team.board.type.BoardCategory;
 import com.sscanner.team.trashcan.type.TrashCategory;
@@ -19,7 +20,7 @@ public interface BoardService {
     BoardResponseDTO updateBoard(Long boardId,
                                  BoardUpdateRequestDTO boardUpdateRequestDTO,
                                  List<MultipartFile> files);
-    Page<BoardListResponseDTO> getBoardList(BoardCategory boardCategory, TrashCategory trashCategory,
+    BoardListResponseDTO getBoardList(BoardCategory boardCategory, TrashCategory trashCategory,
                                          Integer page, Integer size);
     BoardResponseDTO getBoardDetailed(Long boardId);
 

--- a/src/main/java/com/sscanner/team/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/sscanner/team/board/service/BoardServiceImpl.java
@@ -6,6 +6,7 @@ import com.sscanner.team.board.entity.BoardImg;
 import com.sscanner.team.board.repository.BoardRepository;
 import com.sscanner.team.board.requestdto.BoardCreateRequestDTO;
 import com.sscanner.team.board.requestdto.BoardUpdateRequestDTO;
+import com.sscanner.team.board.responsedto.BoardInfoResponseDTO;
 import com.sscanner.team.board.responsedto.BoardListResponseDTO;
 import com.sscanner.team.board.responsedto.BoardResponseDTO;
 import com.sscanner.team.board.type.BoardCategory;
@@ -105,13 +106,18 @@ public class BoardServiceImpl implements BoardService{
      * @return Page<BoardListResponseDTO>
      */
     @Override
-    public Page<BoardListResponseDTO> getBoardList(BoardCategory boardCategory, TrashCategory trashCategory,
+    public BoardListResponseDTO getBoardList(BoardCategory boardCategory, TrashCategory trashCategory,
                                                 Integer page, Integer size) {
         PageRequest pageRequest = PageRequest.of(page, size, Sort.Direction.DESC, "updatedAt");
 
-        Page<Board> boards = boardRepository.findAllByBoardCategoryAndTrashCategory(boardCategory, trashCategory, pageRequest);
+        Page<Board> boards = boardRepository.findAllByCategories(boardCategory, trashCategory, pageRequest);
 
-        return boards.map(board -> BoardListResponseDTO.from(board));
+        Page<BoardInfoResponseDTO> boardInfos = boards.map(board -> {
+            List<BoardImg> boardImgs = boardImgService.getBoardImgs(board.getId());
+            return BoardInfoResponseDTO.of(board, boardImgs.get(0).getBoardImgUrl());
+        });
+
+        return BoardListResponseDTO.from(boardCategory, trashCategory, boardInfos);
     }
 
     /**

--- a/src/main/java/com/sscanner/team/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/sscanner/team/board/service/BoardServiceImpl.java
@@ -1,6 +1,7 @@
 package com.sscanner.team.board.service;
 
 import com.sscanner.team.User;
+import com.sscanner.team.admin.responsedto.AdminBoardInfoResponseDTO;
 import com.sscanner.team.board.entity.Board;
 import com.sscanner.team.board.entity.BoardImg;
 import com.sscanner.team.board.repository.BoardRepository;

--- a/src/main/java/com/sscanner/team/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/sscanner/team/board/service/BoardServiceImpl.java
@@ -1,7 +1,6 @@
 package com.sscanner.team.board.service;
 
 import com.sscanner.team.User;
-import com.sscanner.team.admin.responsedto.AdminBoardInfoResponseDTO;
 import com.sscanner.team.board.entity.Board;
 import com.sscanner.team.board.entity.BoardImg;
 import com.sscanner.team.board.repository.BoardRepository;

--- a/src/main/java/com/sscanner/team/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/sscanner/team/board/service/BoardServiceImpl.java
@@ -84,16 +84,14 @@ public class BoardServiceImpl implements BoardService{
     public BoardResponseDTO updateBoard(Long boardId,
                                            BoardUpdateRequestDTO boardUpdateRequestDTO,
                                            List<MultipartFile> files) {
+        User user = userUtils.getUser();
         Board board = getBoard(boardId);
+
+        isMatchAuthor(user, board);
 
         board.updateBoardInfo(boardUpdateRequestDTO);
 
-        List<BoardImg> boardImgs;
-        if(files.get(0).isEmpty()) {
-            boardImgs = boardImgService.getBoardImgs(boardId);
-        } else {
-            boardImgs = boardImgService.updateBoardImgs(board.getId(), files);
-        }
+        List<BoardImg> boardImgs = getUpdatedImages(files, boardId);
 
         return BoardResponseDTO.of(board, boardImgs);
     }
@@ -136,10 +134,18 @@ public class BoardServiceImpl implements BoardService{
                 .findById(boardId)
                 .orElseThrow(() -> new BadRequestException(NOT_EXIST_BOARD));
     }
+
     private void isMatchAuthor(User user, Board board) {
         if(!board.getUser().equals(user)) {
             throw new BadRequestException(MISMATCH_BOARD_AUTHOR);
         }
     }
 
+    private List<BoardImg> getUpdatedImages(List<MultipartFile> files, Long boardId) {
+        if(files.get(0).isEmpty()) {
+            return boardImgService.getBoardImgs(boardId);
+        } else {
+            return boardImgService.updateBoardImgs(boardId, files);
+        }
+    }
 }

--- a/src/main/java/com/sscanner/team/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/sscanner/team/board/service/BoardServiceImpl.java
@@ -10,8 +10,8 @@ import com.sscanner.team.board.responsedto.BoardListResponseDTO;
 import com.sscanner.team.board.responsedto.BoardResponseDTO;
 import com.sscanner.team.board.type.BoardCategory;
 import com.sscanner.team.global.exception.BadRequestException;
+import com.sscanner.team.global.utils.UserUtils;
 import com.sscanner.team.trashcan.type.TrashCategory;
-import com.sscanner.team.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -33,7 +33,7 @@ public class BoardServiceImpl implements BoardService{
 
     private final BoardRepository boardRepository;
     private final BoardImgService boardImgService;
-    private final UserRepository userRepository;
+    private final UserUtils userUtils;
 
     /**
      * 추가, 수정, 삭제 신고 게시글 등록
@@ -45,15 +45,15 @@ public class BoardServiceImpl implements BoardService{
     @Override
     public BoardResponseDTO createBoard(BoardCreateRequestDTO boardCreateRequestDTO,
                                         List<MultipartFile> files) {
-        User user = userRepository.findById(boardCreateRequestDTO.userId()).get();
-        // null에 user 들어갈 예정
-        Board addBoard = boardCreateRequestDTO.toEntityAddBoard(user);
+        User user = userUtils.getUser();
 
-        Board savedAddBoard = boardRepository.save(addBoard);
+        Board board = boardCreateRequestDTO.toEntityBoard(user);
 
-        List<BoardImg> boardImgs = boardImgService.saveBoardImg(savedAddBoard.getId(), files);
+        Board savedBoard = boardRepository.save(board);
 
-        return BoardResponseDTO.of(savedAddBoard, boardImgs);
+        List<BoardImg> boardImgs = boardImgService.saveBoardImg(savedBoard.getId(), files);
+
+        return BoardResponseDTO.of(savedBoard, boardImgs);
     }
 
     /**

--- a/src/main/java/com/sscanner/team/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/sscanner/team/board/service/BoardServiceImpl.java
@@ -63,11 +63,13 @@ public class BoardServiceImpl implements BoardService{
     @Transactional
     @Override
     public void deleteBoard(Long boardId) {
+        User user = userUtils.getUser();
         Board board = getBoard(boardId);
 
-        boardImgService.deleteBoardImgs(board.getId());
+        isMatchAuthor(user, board);
 
         boardRepository.delete(board);
+        boardImgService.deleteBoardImgs(boardId);
     }
 
     /**
@@ -133,6 +135,11 @@ public class BoardServiceImpl implements BoardService{
         return boardRepository
                 .findById(boardId)
                 .orElseThrow(() -> new BadRequestException(NOT_EXIST_BOARD));
+    }
+    private void isMatchAuthor(User user, Board board) {
+        if(!board.getUser().equals(user)) {
+            throw new BadRequestException(MISMATCH_BOARD_AUTHOR);
+        }
     }
 
 }

--- a/src/main/java/com/sscanner/team/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/sscanner/team/board/service/BoardServiceImpl.java
@@ -8,6 +8,7 @@ import com.sscanner.team.board.requestdto.BoardCreateRequestDTO;
 import com.sscanner.team.board.requestdto.BoardUpdateRequestDTO;
 import com.sscanner.team.board.responsedto.BoardInfoResponseDTO;
 import com.sscanner.team.board.responsedto.BoardListResponseDTO;
+import com.sscanner.team.board.responsedto.BoardLocationInfoResponseDTO;
 import com.sscanner.team.board.responsedto.BoardResponseDTO;
 import com.sscanner.team.board.type.BoardCategory;
 import com.sscanner.team.global.exception.BadRequestException;
@@ -132,6 +133,18 @@ public class BoardServiceImpl implements BoardService{
         List<BoardImg> boardImgs = boardImgService.getBoardImgs(boardId);
 
         return BoardResponseDTO.of(board, boardImgs);
+    }
+
+    /**
+     * 게시글 위치 정보 조회
+     * @param boardId - 게시글 id
+     * @return BoardLocationInfoResponseDTO 위치 정보
+     */
+    @Override
+    public BoardLocationInfoResponseDTO getBoardLocationInfo(Long boardId) {
+        Board board = getBoard(boardId);
+
+        return BoardLocationInfoResponseDTO.from(board);
     }
 
     @Override

--- a/src/main/java/com/sscanner/team/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/sscanner/team/board/service/BoardServiceImpl.java
@@ -156,7 +156,7 @@ public class BoardServiceImpl implements BoardService{
 
     private void isMatchAuthor(User user, Board board) {
         if(!board.getUser().equals(user)) {
-            throw new BadRequestException(MISMATCH_BOARD_AUTHOR);
+            throw new BadRequestException(MISMATCH_AUTHOR);
         }
     }
 

--- a/src/main/java/com/sscanner/team/board/type/ApprovalStatus.java
+++ b/src/main/java/com/sscanner/team/board/type/ApprovalStatus.java
@@ -1,0 +1,7 @@
+package com.sscanner.team.board.type;
+
+public enum ApprovalStatus {
+    REVIEWING,
+    APPROVED,
+    REJECTED
+}

--- a/src/main/java/com/sscanner/team/comment/controller/CommentController.java
+++ b/src/main/java/com/sscanner/team/comment/controller/CommentController.java
@@ -4,6 +4,7 @@ import com.sscanner.team.comment.requestdto.CommentCreateRequestDTO;
 import com.sscanner.team.comment.responsedto.CommentResponseDTO;
 import com.sscanner.team.comment.service.CommentService;
 import com.sscanner.team.global.common.response.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,7 +16,7 @@ public class CommentController {
     private final CommentService commentService;
 
     @PostMapping
-    public ApiResponse<CommentResponseDTO> createComment(@RequestBody CommentCreateRequestDTO commentCreateRequestDTO) {
+    public ApiResponse<CommentResponseDTO> createComment(@Valid @RequestBody CommentCreateRequestDTO commentCreateRequestDTO) {
         CommentResponseDTO commentInfo = commentService.saveComment(commentCreateRequestDTO);
 
         return ApiResponse.ok(201, commentInfo, "댓글 생성 완료!!");

--- a/src/main/java/com/sscanner/team/comment/controller/CommentController.java
+++ b/src/main/java/com/sscanner/team/comment/controller/CommentController.java
@@ -37,4 +37,11 @@ public class CommentController {
 
         return ApiResponse.ok(200, comments, "댓글 조회 완료!!");
     }
+
+    @DeleteMapping("/all/{boardId}")
+    public ApiResponse<Void> deleteAllComments(@PathVariable Long boardId) {
+        commentService.deleteAll(boardId);
+
+        return ApiResponse.ok(200, null, "모든 댓글 삭제 완료!!");
+    }
 }

--- a/src/main/java/com/sscanner/team/comment/controller/CommentController.java
+++ b/src/main/java/com/sscanner/team/comment/controller/CommentController.java
@@ -8,6 +8,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/comments")
@@ -27,5 +29,12 @@ public class CommentController {
         commentService.deleteComment(commmentId);
 
         return ApiResponse.ok(200, null, "댓글 삭제 완료!!");
+    }
+
+    @GetMapping("/{boardId}")
+    public ApiResponse<List<CommentResponseDTO>> getComments(@PathVariable Long boardId) {
+        List<CommentResponseDTO> comments = commentService.getComments(boardId);
+
+        return ApiResponse.ok(200, comments, "댓글 조회 완료!!");
     }
 }

--- a/src/main/java/com/sscanner/team/comment/repository/CommentRepository.java
+++ b/src/main/java/com/sscanner/team/comment/repository/CommentRepository.java
@@ -2,6 +2,12 @@ package com.sscanner.team.comment.repository;
 
 import com.sscanner.team.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    @Query("select c from Comment c where c.boardId = :boardId")
+    List<Comment> findAllByBoardId(@Param("boardId") Long boardId);
 }

--- a/src/main/java/com/sscanner/team/comment/repository/CommentRepository.java
+++ b/src/main/java/com/sscanner/team/comment/repository/CommentRepository.java
@@ -2,6 +2,7 @@ package com.sscanner.team.comment.repository;
 
 import com.sscanner.team.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -10,4 +11,8 @@ import java.util.List;
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     @Query("select c from Comment c where c.boardId = :boardId")
     List<Comment> findAllByBoardId(@Param("boardId") Long boardId);
+
+    @Modifying
+    @Query("update Comment c set c.deletedAt = NOW() where c.boardId = :boardId")
+    void deleteAllByBoardId(@Param("boardId") Long boardId);
 }

--- a/src/main/java/com/sscanner/team/comment/requestdto/CommentCreateRequestDTO.java
+++ b/src/main/java/com/sscanner/team/comment/requestdto/CommentCreateRequestDTO.java
@@ -2,13 +2,14 @@ package com.sscanner.team.comment.requestdto;
 
 import com.sscanner.team.User;
 import com.sscanner.team.comment.entity.Comment;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record CommentCreateRequestDTO(
         @NotNull(message = "boardId 작성은 필수입니다.")
         Long boardId,
 
-        @NotNull(message = "내용 작성은 필수입니다.")
+        @NotBlank(message = "내용 작성은 필수입니다.")
         String content
 ) {
     public Comment toEntityComment(User user) {

--- a/src/main/java/com/sscanner/team/comment/responsedto/CommentResponseDTO.java
+++ b/src/main/java/com/sscanner/team/comment/responsedto/CommentResponseDTO.java
@@ -1,6 +1,5 @@
 package com.sscanner.team.comment.responsedto;
 
-import com.sscanner.team.User;
 import com.sscanner.team.comment.entity.Comment;
 
 public record CommentResponseDTO(
@@ -9,11 +8,11 @@ public record CommentResponseDTO(
         String authority,
         String content
 ) {
-    public static CommentResponseDTO of(Comment comment, User user) {
+    public static CommentResponseDTO from(Comment comment) {
         return new CommentResponseDTO(
                 comment.getId(),
-                user.getNickname(),
-                user.getAuthority(),
+                comment.getUser().getNickname(),
+                comment.getUser().getAuthority(),
                 comment.getContent()
         );
     }

--- a/src/main/java/com/sscanner/team/comment/service/CommentService.java
+++ b/src/main/java/com/sscanner/team/comment/service/CommentService.java
@@ -9,4 +9,5 @@ public interface CommentService {
     CommentResponseDTO saveComment(CommentCreateRequestDTO commentCreateRequestDTO);
     void deleteComment(Long commentId);
     List<CommentResponseDTO> getComments(Long boardId);
+    void deleteAll(Long boardId);
 }

--- a/src/main/java/com/sscanner/team/comment/service/CommentService.java
+++ b/src/main/java/com/sscanner/team/comment/service/CommentService.java
@@ -3,7 +3,10 @@ package com.sscanner.team.comment.service;
 import com.sscanner.team.comment.requestdto.CommentCreateRequestDTO;
 import com.sscanner.team.comment.responsedto.CommentResponseDTO;
 
+import java.util.List;
+
 public interface CommentService {
     CommentResponseDTO saveComment(CommentCreateRequestDTO commentCreateRequestDTO);
     void deleteComment(Long commentId);
+    List<CommentResponseDTO> getComments(Long boardId);
 }

--- a/src/main/java/com/sscanner/team/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/sscanner/team/comment/service/CommentServiceImpl.java
@@ -12,6 +12,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static com.sscanner.team.global.exception.ExceptionCode.*;
 
 @Service
@@ -34,7 +37,7 @@ public class CommentServiceImpl implements CommentService{
 
         commentRepository.save(comment);
 
-        return CommentResponseDTO.of(comment, user);
+        return CommentResponseDTO.from(comment);
     }
 
     @Transactional
@@ -46,6 +49,15 @@ public class CommentServiceImpl implements CommentService{
         isMatchAuthor(user, comment);
 
         commentRepository.delete(comment);
+    }
+
+    @Override
+    public List<CommentResponseDTO> getComments(Long boardId) {
+        List<Comment> comments = commentRepository.findAllByBoardId(boardId);
+
+        return comments.stream()
+                .map(comment -> CommentResponseDTO.from(comment))
+                .collect(Collectors.toList());
     }
 
     private Comment getComment(Long commentId) {

--- a/src/main/java/com/sscanner/team/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/sscanner/team/comment/service/CommentServiceImpl.java
@@ -16,6 +16,7 @@ import static com.sscanner.team.global.exception.ExceptionCode.*;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class CommentServiceImpl implements CommentService{
 
     private final CommentRepository commentRepository;
@@ -39,7 +40,11 @@ public class CommentServiceImpl implements CommentService{
     @Transactional
     @Override
     public void deleteComment(Long commentId) {
+        User user = userUtils.getUser();
         Comment comment = getComment(commentId);
+
+        isMatchAuthor(user, comment);
+
         commentRepository.delete(comment);
     }
 
@@ -47,5 +52,11 @@ public class CommentServiceImpl implements CommentService{
         return commentRepository
                 .findById(commentId)
                 .orElseThrow(() -> new BadRequestException(NOT_EXIST_COMMENT));
+    }
+
+    private void isMatchAuthor(User user, Comment comment) {
+        if(!comment.getUser().equals(user)) {
+            throw new BadRequestException(MISMATCH_AUTHOR);
+        }
     }
 }

--- a/src/main/java/com/sscanner/team/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/sscanner/team/comment/service/CommentServiceImpl.java
@@ -40,8 +40,8 @@ public class CommentServiceImpl implements CommentService{
         return CommentResponseDTO.from(comment);
     }
 
-    @Transactional
     @Override
+    @Transactional
     public void deleteComment(Long commentId) {
         User user = userUtils.getUser();
         Comment comment = getComment(commentId);
@@ -61,6 +61,7 @@ public class CommentServiceImpl implements CommentService{
     }
 
     @Override
+    @Transactional
     public void deleteAll(Long boardId) {
         commentRepository.deleteAllByBoardId(boardId);
     }

--- a/src/main/java/com/sscanner/team/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/sscanner/team/comment/service/CommentServiceImpl.java
@@ -60,6 +60,11 @@ public class CommentServiceImpl implements CommentService{
                 .collect(Collectors.toList());
     }
 
+    @Override
+    public void deleteAll(Long boardId) {
+        commentRepository.deleteAllByBoardId(boardId);
+    }
+
     private Comment getComment(Long commentId) {
         return commentRepository
                 .findById(commentId)

--- a/src/main/java/com/sscanner/team/global/exception/ExceptionCode.java
+++ b/src/main/java/com/sscanner/team/global/exception/ExceptionCode.java
@@ -45,7 +45,7 @@ public enum ExceptionCode {
     DAILY_POINTS_EXCEEDED(400, "일일 획득 포인트를 초과했습니다."),
     FILE_UPLOAD_FAIL(400,  "파일 업로드를 실패하였습니다."),
     MISMATCH_BOARD_TYPE(400, "신고 게시글 유형이 적절하지 않습니다"),
-    MISMATCH_BOARD_AUTHOR(400, "게시글 작성자가 아닙니다."),
+    MISMATCH_AUTHOR(400, "작성자가 일치하지 않습니다."),
 
     DUPLICATED_EMAIL(409, "이미 가입된 이메일입니다. "),
     DUPLICATED_NICKNAME(409, "이미 가입된 닉네임입니다. "),

--- a/src/main/java/com/sscanner/team/global/exception/ExceptionCode.java
+++ b/src/main/java/com/sscanner/team/global/exception/ExceptionCode.java
@@ -44,6 +44,8 @@ public enum ExceptionCode {
     NOT_ENOUGH_POINTS(400, "사용 가능한 포인트가 부족합니다."),
     DAILY_POINTS_EXCEEDED(400, "일일 획득 포인트를 초과했습니다."),
     FILE_UPLOAD_FAIL(400,  "파일 업로드를 실패하였습니다."),
+    MISMATCH_BOARD_TYPE(400, "신고 게시글 유형이 적절하지 않습니다"),
+    MISMATCH_BOARD_AUTHOR(400, "게시글 작성자가 아닙니다."),
 
     DUPLICATED_EMAIL(409, "이미 가입된 이메일입니다. "),
     DUPLICATED_NICKNAME(409, "이미 가입된 닉네임입니다. "),


### PR DESCRIPTION
resolved : #56

## 📌 과제 설명
전체적으로 테스트 해보고 리펙토링 진행했습니다

## 👩‍💻 요구 사항과 구현 내용 
- userUtils를 의존관계 주입하여 토큰에서 User를 가져올 수 있게끔 하였습니다.
- 토큰의 User와 작성자가 일치 하는지 확인하는 로직을 추가하였습니다.
- 게시글 위치 정보는 따로 API를 작성하였습니다. 
- 모든 댓글을 조회하는 로직, 삭제하는 로직 작성하였습니다.

## ✅ 피드백 반영사항  

## ✅ PR 포인트 & 궁금한 점 
- CommentServiceImpl에서 댓글 생성 시 boardId를 통해 해당 게시글이 있는지 확인하기 위해서  BoardService를 주입 받아 getBoard() 메서드를 사용하였습니다. 그리고 BoardServiceImpl에서 게시글 삭제 시 관련된 모든 댓글을 삭제하기 위해서 CommentService를 주입 받아서 deleteAll() 메서드를 사용하려고 하니 순환 참조가 발생하였습니다. 그래서 따로 API를 두기는 했는데 다른 좋은 해결 방법이 있을까요?? 
