### PR TITLE
Feature/38 add admin

### DIFF
--- a/src/main/java/com/sscanner/team/admin/controller/AdminController.java
+++ b/src/main/java/com/sscanner/team/admin/controller/AdminController.java
@@ -1,0 +1,58 @@
+package com.sscanner.team.admin.controller;
+
+import com.sscanner.team.admin.requestdto.AdminBoardRequestDTO;
+import com.sscanner.team.admin.responsedto.AdminBoardListResponseDTO;
+import com.sscanner.team.admin.responsedto.AdminEctBoardResponseDTO;
+import com.sscanner.team.admin.responsedto.AdminModifyBoardResponseDTO;
+import com.sscanner.team.admin.service.AdminService;
+import com.sscanner.team.board.type.ApprovalStatus;
+import com.sscanner.team.board.type.BoardCategory;
+import com.sscanner.team.global.common.response.ApiResponse;
+import com.sscanner.team.trashcan.type.TrashCategory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    // 관리자 게시글 리스트 페이지
+    @GetMapping("/boards")
+    public ApiResponse<AdminBoardListResponseDTO> readAllBoards(
+            @RequestParam(value = "approval_status", defaultValue = "REVIEWING") ApprovalStatus approvalStatus,
+            @RequestParam(value = "board_category", defaultValue = "MODIFY") BoardCategory boardCategory,
+            @RequestParam(value = "trash_category", defaultValue = "NORMAL") TrashCategory trashCategory,
+            @RequestParam(value = "page", defaultValue = "0") Integer page,
+            @RequestParam(value = "size", defaultValue = "6") Integer size) {
+        AdminBoardListResponseDTO boards =
+                adminService.getBoards(approvalStatus, trashCategory, boardCategory, page, size);
+
+        return ApiResponse.ok(200, boards, "관리자 게시글 목록 조회 완료!!");
+    }
+
+    @GetMapping("/boards/modify/{boardId}")
+    public ApiResponse<AdminModifyBoardResponseDTO> readModifyBoardDetailed(@PathVariable Long boardId) {
+        AdminModifyBoardResponseDTO modifyBoard = adminService.getModifyBoard(boardId);
+
+        return ApiResponse.ok(200, modifyBoard, "관리자 수정 신고 게시글 상세 조회 완료!!");
+    }
+
+    @GetMapping("/boards/ect/{boardId}")
+    public ApiResponse<AdminEctBoardResponseDTO> readEctBoardDetailed(@PathVariable Long boardId) {
+        AdminEctBoardResponseDTO ectBoard = adminService.getEctBoard(boardId);
+
+        return ApiResponse.ok(200, ectBoard, "어드민 등록 및 삭제 신고 게시글 상세 조회 완료!!");
+    }
+
+    @PatchMapping("/boards/{boardId}")
+    public ApiResponse<?> reflectBoard(
+            @PathVariable Long boardId,
+            @RequestBody AdminBoardRequestDTO adminBoardRequestDTO) {
+        adminService.reflectBoard(boardId, adminBoardRequestDTO);
+
+        return ApiResponse.ok(200, "관리자 신고 게시글 반영 완료!!");
+    }
+}

--- a/src/main/java/com/sscanner/team/admin/requestdto/AdminBoardRequestDTO.java
+++ b/src/main/java/com/sscanner/team/admin/requestdto/AdminBoardRequestDTO.java
@@ -1,0 +1,14 @@
+package com.sscanner.team.admin.requestdto;
+
+import com.sscanner.team.board.type.ApprovalStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record AdminBoardRequestDTO(
+        @NotNull(message = "사진 선택은 필수입니다.")
+        String chosenImgUrl,
+
+        @NotNull(message = "승인 선택은 필수입니다. 승인, 거절 중 골라주세요")
+        ApprovalStatus approvalStatus
+) {
+
+}

--- a/src/main/java/com/sscanner/team/admin/responsedto/AdminBoardInfoResponseDTO.java
+++ b/src/main/java/com/sscanner/team/admin/responsedto/AdminBoardInfoResponseDTO.java
@@ -1,0 +1,22 @@
+package com.sscanner.team.admin.responsedto;
+
+import com.sscanner.team.board.entity.Board;
+import com.sscanner.team.board.type.ApprovalStatus;
+
+public record AdminBoardInfoResponseDTO(
+        Long id,
+        String boardFirstImgUrl,
+        String roadNameAddress,
+        String detailedAddress,
+        ApprovalStatus approvalStatus
+) {
+    public static AdminBoardInfoResponseDTO of(Board board, String boardFirstImgUrl) {
+        return new AdminBoardInfoResponseDTO(
+                board.getId(),
+                boardFirstImgUrl,
+                board.getRoadNameAddress(),
+                board.getDetailedAddress(),
+                board.getApprovalStatus()
+        );
+    }
+}

--- a/src/main/java/com/sscanner/team/admin/responsedto/AdminBoardListResponseDTO.java
+++ b/src/main/java/com/sscanner/team/admin/responsedto/AdminBoardListResponseDTO.java
@@ -1,0 +1,25 @@
+package com.sscanner.team.admin.responsedto;
+
+import com.sscanner.team.board.type.ApprovalStatus;
+import com.sscanner.team.board.type.BoardCategory;
+import com.sscanner.team.trashcan.type.TrashCategory;
+import org.springframework.data.domain.Page;
+
+public record AdminBoardListResponseDTO(
+        ApprovalStatus approvalStatus,
+        TrashCategory trashCategory,
+        BoardCategory boardCategory,
+        Page<AdminBoardInfoResponseDTO> boardList
+) {
+    public static AdminBoardListResponseDTO of(ApprovalStatus approvalStatus,
+                                               TrashCategory trashCategory,
+                                               BoardCategory boardCategory,
+                                               Page<AdminBoardInfoResponseDTO> boards) {
+        return new AdminBoardListResponseDTO(
+                approvalStatus,
+                trashCategory,
+                boardCategory,
+                boards
+        );
+    }
+}

--- a/src/main/java/com/sscanner/team/admin/responsedto/AdminEctBoardResponseDTO.java
+++ b/src/main/java/com/sscanner/team/admin/responsedto/AdminEctBoardResponseDTO.java
@@ -1,0 +1,30 @@
+package com.sscanner.team.admin.responsedto;
+
+import com.sscanner.team.board.entity.Board;
+import com.sscanner.team.board.entity.BoardImg;
+import com.sscanner.team.board.responsedto.BoardImgResponseDTO;
+import com.sscanner.team.board.type.BoardCategory;
+import com.sscanner.team.trashcan.type.TrashCategory;
+import com.sscanner.team.trashcan.type.TrashcanStatus;
+
+import java.util.List;
+
+public record AdminEctBoardResponseDTO(
+        BoardCategory boardCategory,
+        TrashCategory trashCategory,
+        List<BoardImgResponseDTO> images,
+        TrashcanStatus trashcanStatus,
+        String significant
+) {
+    public static AdminEctBoardResponseDTO of(Board board, List<BoardImg> boardImgs) {
+        return new AdminEctBoardResponseDTO(
+                board.getBoardCategory(),
+                board.getTrashCategory(),
+                boardImgs.stream()
+                        .map(boardImg -> BoardImgResponseDTO.from(boardImg))
+                        .toList(),
+                board.getUpdatedTrashcanStatus(),
+                board.getSignificant()
+        );
+    }
+}

--- a/src/main/java/com/sscanner/team/admin/responsedto/AdminModifyBoardResponseDTO.java
+++ b/src/main/java/com/sscanner/team/admin/responsedto/AdminModifyBoardResponseDTO.java
@@ -1,0 +1,31 @@
+package com.sscanner.team.admin.responsedto;
+
+import com.sscanner.team.board.entity.Board;
+import com.sscanner.team.board.entity.BoardImg;
+import com.sscanner.team.trashcan.entity.Trashcan;
+import com.sscanner.team.trashcan.entity.TrashcanImg;
+import com.sscanner.team.trashcan.type.TrashCategory;
+import com.sscanner.team.trashcan.type.TrashcanStatus;
+
+import java.util.List;
+
+public record AdminModifyBoardResponseDTO(
+        TrashCategory trashCategory,
+        String trashcanImgUrl,
+        TrashcanStatus trashcanStatus,
+        List<String> boardImgUrls,
+        TrashcanStatus updatedTrashcanStatus,
+        String significant
+) {
+    public static AdminModifyBoardResponseDTO of(Trashcan trashcan, TrashcanImg trashcanImg,
+                                                   Board board, List<BoardImg> boardImgs) {
+        return new AdminModifyBoardResponseDTO(
+                trashcan.getTrashCategory(),
+                trashcanImg.getTrashcanImgUrl(),
+                trashcan.getTrashcanStatus(),
+                boardImgs.stream().map(boardImg -> boardImg.getBoardImgUrl()).toList(),
+                board.getUpdatedTrashcanStatus(),
+                board.getSignificant()
+        );
+    }
+}

--- a/src/main/java/com/sscanner/team/admin/service/AdminService.java
+++ b/src/main/java/com/sscanner/team/admin/service/AdminService.java
@@ -1,0 +1,17 @@
+package com.sscanner.team.admin.service;
+
+import com.sscanner.team.admin.requestdto.AdminBoardRequestDTO;
+import com.sscanner.team.admin.responsedto.AdminBoardListResponseDTO;
+import com.sscanner.team.admin.responsedto.AdminEctBoardResponseDTO;
+import com.sscanner.team.admin.responsedto.AdminModifyBoardResponseDTO;
+import com.sscanner.team.board.type.ApprovalStatus;
+import com.sscanner.team.board.type.BoardCategory;
+import com.sscanner.team.trashcan.type.TrashCategory;
+
+public interface AdminService {
+    AdminBoardListResponseDTO getBoards(ApprovalStatus approvalStatus, TrashCategory trashCategory,
+                                        BoardCategory boardCategory, Integer page, Integer size);
+    AdminModifyBoardResponseDTO getModifyBoard(Long boardId);
+    AdminEctBoardResponseDTO getEctBoard(Long boardId);
+    void reflectBoard(Long boardId, AdminBoardRequestDTO adminBoardRequestDTO);
+}

--- a/src/main/java/com/sscanner/team/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/sscanner/team/admin/service/AdminServiceImpl.java
@@ -1,0 +1,139 @@
+package com.sscanner.team.admin.service;
+
+import com.sscanner.team.admin.requestdto.AdminBoardRequestDTO;
+import com.sscanner.team.admin.responsedto.AdminBoardInfoResponseDTO;
+import com.sscanner.team.admin.responsedto.AdminBoardListResponseDTO;
+import com.sscanner.team.admin.responsedto.AdminEctBoardResponseDTO;
+import com.sscanner.team.admin.responsedto.AdminModifyBoardResponseDTO;
+import com.sscanner.team.board.entity.Board;
+import com.sscanner.team.board.entity.BoardImg;
+import com.sscanner.team.board.service.BoardImgService;
+import com.sscanner.team.board.service.BoardService;
+import com.sscanner.team.board.type.ApprovalStatus;
+import com.sscanner.team.board.type.BoardCategory;
+import com.sscanner.team.global.exception.BadRequestException;
+import com.sscanner.team.trashcan.entity.Trashcan;
+import com.sscanner.team.trashcan.entity.TrashcanImg;
+import com.sscanner.team.trashcan.service.TrashcanImgService;
+import com.sscanner.team.trashcan.service.TrashcanService;
+import com.sscanner.team.trashcan.type.TrashCategory;
+import com.sscanner.team.trashcan.type.TrashcanStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.sscanner.team.global.exception.ExceptionCode.MISMATCH_BOARD_TYPE;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminServiceImpl implements AdminService {
+
+    private final BoardService boardService;
+    private final BoardImgService boardImgService;
+    private final TrashcanService trashcanService;
+    private final TrashcanImgService trashcanImgService;
+
+    @Override
+    public AdminBoardListResponseDTO getBoards(ApprovalStatus approvalStatus, TrashCategory trashCategory,
+                                               BoardCategory boardCategory, Integer page, Integer size) {
+        Page<AdminBoardInfoResponseDTO> pageBoards =
+                boardService.getBoardsForAdmin(approvalStatus, trashCategory, boardCategory, page, size);
+
+        return AdminBoardListResponseDTO.of(approvalStatus, trashCategory, boardCategory, pageBoards);
+    }
+
+    @Override
+    public AdminModifyBoardResponseDTO getModifyBoard(Long boardId) {
+        Board board = boardService.getBoard(boardId);
+
+        isModifyBoard(board);
+
+        List<BoardImg> boardImgs = boardImgService.getBoardImgs(boardId);
+
+        Trashcan trashcan = trashcanService.getTrashcanById(board.getTrashcanId());
+        TrashcanImg trashcanImg = trashcanImgService.getTrashcanImg(board.getTrashcanId());
+
+        return AdminModifyBoardResponseDTO.of(trashcan, trashcanImg, board, boardImgs);
+    }
+
+    @Override
+    public AdminEctBoardResponseDTO getEctBoard(Long boardId) {
+        Board board = boardService.getBoard(boardId);
+
+        isNotModifyBoard(board);
+
+        List<BoardImg> boardImgs = boardImgService.getBoardImgs(boardId);
+
+        return AdminEctBoardResponseDTO.of(board, boardImgs);
+    }
+
+    @Transactional
+    @Override
+    public void reflectBoard(Long boardId, AdminBoardRequestDTO adminBoardRequestDTO) {
+        Board board = boardService.getBoard(boardId);
+
+        ApprovalStatus approvalStatus = adminBoardRequestDTO.approvalStatus();
+        String chosenImgUrl = adminBoardRequestDTO.chosenImgUrl();
+
+        boardImgService.checkExistImgUrl(boardId, chosenImgUrl);
+
+        processBoardApproval(approvalStatus, board, chosenImgUrl);
+
+        board.changeApprovalStatus(approvalStatus);
+    }
+
+    private void processBoardApproval(ApprovalStatus approvalStatus, Board board, String chosenImgUrl) {
+        if(approvalStatus.equals(ApprovalStatus.APPROVED)) {
+            BoardCategory boardCategory = board.getBoardCategory();
+            if(boardCategory.equals(BoardCategory.MODIFY)) {
+                approveModifyBoard(board.getTrashcanId(), board.getUpdatedTrashcanStatus(), chosenImgUrl);
+            } else if(boardCategory.equals(BoardCategory.REMOVE)) {
+                approveRemoveBoard(board.getTrashcanId());
+            } else if(boardCategory.equals(BoardCategory.ADD)) {
+                approveAddBoard(board, chosenImgUrl);
+            }
+        }
+    }
+
+    private void approveModifyBoard(Long trashcanId,
+                                   TrashcanStatus updatedTrashcanStatus,
+                                   String chosenImgUrl) {
+        Trashcan trashcan = trashcanService.getTrashcanById(trashcanId);
+        TrashcanImg trashcanImg = trashcanImgService.getTrashcanImg(trashcanId);
+
+        trashcan.changeTrashcanStatus(updatedTrashcanStatus);
+        trashcanImg.changeImgUrl(chosenImgUrl);
+    }
+
+    private void approveRemoveBoard(Long trashcanId) {
+        Trashcan trashcan = trashcanService.getTrashcanById(trashcanId);
+
+        trashcanService.deleteTrashcanInfo(trashcan.getId());
+        trashcanImgService.deleteTrashcanImg(trashcan.getId());
+    }
+
+    private void approveAddBoard(Board board, String chosenImgUrl) {
+        Trashcan trashcan = board.toEntityTrashcan();
+
+        trashcanService.saveTrashcan(trashcan);
+        trashcanImgService.saveTrashcanImg(trashcan.getId(), chosenImgUrl);
+
+        board.changeTrashcanId(trashcan.getId());
+    }
+
+    private void isModifyBoard(Board board) {
+        if(!board.getBoardCategory().equals(BoardCategory.MODIFY)) {
+            throw new BadRequestException(MISMATCH_BOARD_TYPE);
+        }
+    }
+
+    private void isNotModifyBoard(Board board) {
+        if(board.getBoardCategory().equals(BoardCategory.MODIFY)) {
+            throw new BadRequestException(MISMATCH_BOARD_TYPE);
+        }
+    }
+}

--- a/src/main/java/com/sscanner/team/admin/service/AdminServiceImpl.java
+++ b/src/main/java/com/sscanner/team/admin/service/AdminServiceImpl.java
@@ -81,21 +81,28 @@ public class AdminServiceImpl implements AdminService {
 
         boardImgService.checkExistImgUrl(boardId, chosenImgUrl);
 
-        processBoardApproval(approvalStatus, board, chosenImgUrl);
+        if(approvalStatus.equals(ApprovalStatus.APPROVED)) {
+            processBoardApproval(board, chosenImgUrl);
+        }
 
         board.changeApprovalStatus(approvalStatus);
     }
 
-    private void processBoardApproval(ApprovalStatus approvalStatus, Board board, String chosenImgUrl) {
-        if(approvalStatus.equals(ApprovalStatus.APPROVED)) {
-            BoardCategory boardCategory = board.getBoardCategory();
-            if(boardCategory.equals(BoardCategory.MODIFY)) {
+    private void processBoardApproval(Board board, String chosenImgUrl) {
+        BoardCategory boardCategory = board.getBoardCategory();
+
+        switch (boardCategory) {
+            case MODIFY:
                 approveModifyBoard(board.getTrashcanId(), board.getUpdatedTrashcanStatus(), chosenImgUrl);
-            } else if(boardCategory.equals(BoardCategory.REMOVE)) {
+                break;
+            case REMOVE:
                 approveRemoveBoard(board.getTrashcanId());
-            } else if(boardCategory.equals(BoardCategory.ADD)) {
+                break;
+            case ADD:
                 approveAddBoard(board, chosenImgUrl);
-            }
+                break;
+            default:
+                throw new BadRequestException(MISMATCH_BOARD_TYPE);
         }
     }
 

--- a/src/main/java/com/sscanner/team/board/entity/Board.java
+++ b/src/main/java/com/sscanner/team/board/entity/Board.java
@@ -5,6 +5,7 @@ import com.sscanner.team.board.requestdto.BoardUpdateRequestDTO;
 import com.sscanner.team.board.type.ApprovalStatus;
 import com.sscanner.team.board.type.BoardCategory;
 import com.sscanner.team.global.common.BaseEntity;
+import com.sscanner.team.trashcan.entity.Trashcan;
 import com.sscanner.team.trashcan.type.TrashCategory;
 import com.sscanner.team.trashcan.type.TrashcanStatus;
 import jakarta.persistence.*;
@@ -100,5 +101,23 @@ public class Board extends BaseEntity {
         this.detailedAddress = boardUpdateRequestDTO.detailedAddress();
         this.trashCategory = boardUpdateRequestDTO.trashCategory();
         this.updatedTrashcanStatus = boardUpdateRequestDTO.updatedTrashcanStatus();
+    }
+
+    public void changeApprovalStatus(ApprovalStatus approvalStatus) {
+        this.approvalStatus = approvalStatus;
+    }
+
+    public void changeTrashcanId(Long trashcanId) {
+        this.trashcanId = trashcanId;
+    }
+
+    public Trashcan toEntityTrashcan() {
+        return Trashcan.builder()
+                .latitude(this.latitude)
+                .longitude(this.longitude)
+                .roadNameAddress(this.roadNameAddress)
+                .detailedAddress(this.detailedAddress)
+                .trashCategory(this.trashCategory)
+                .build();
     }
 }

--- a/src/main/java/com/sscanner/team/board/repository/BoardImgRepository.java
+++ b/src/main/java/com/sscanner/team/board/repository/BoardImgRepository.java
@@ -14,4 +14,6 @@ public interface BoardImgRepository extends JpaRepository<BoardImg, Long> {
     @Modifying
     @Query("update BoardImg bi set bi.deletedAt = NOW() where bi.boardId = :boardId")
     void deleteAll(@Param("boardId") Long boardId);
+
+    boolean existsByBoardIdAndAndBoardImgUrl(Long boardId, String imgUrl);
 }

--- a/src/main/java/com/sscanner/team/board/repository/BoardRepository.java
+++ b/src/main/java/com/sscanner/team/board/repository/BoardRepository.java
@@ -1,6 +1,7 @@
 package com.sscanner.team.board.repository;
 
 import com.sscanner.team.board.entity.Board;
+import com.sscanner.team.board.type.ApprovalStatus;
 import com.sscanner.team.board.type.BoardCategory;
 import com.sscanner.team.trashcan.type.TrashCategory;
 import org.springframework.data.domain.Page;
@@ -14,4 +15,10 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     Page<Board> findAllByCategories(@Param("boardCategory") BoardCategory boardCategory,
                                                        @Param("trashCategory")TrashCategory trashCategory,
                                                        Pageable pageable);
+
+    @Query("select b from Board b where b.approvalStatus = :approvalStatus and b.boardCategory = :boardCategory and b.trashCategory = :trashCategory")
+    Page<Board> findAllByStatusAndCategories(@Param("approvalStatus") ApprovalStatus approvalStatus,
+                                             @Param("boardCategory") BoardCategory boardCategory,
+                                             @Param("trashCategory") TrashCategory trashCategory,
+                                             Pageable pageable);
 }

--- a/src/main/java/com/sscanner/team/board/service/BoardImgService.java
+++ b/src/main/java/com/sscanner/team/board/service/BoardImgService.java
@@ -10,4 +10,5 @@ public interface BoardImgService {
     void deleteBoardImgs(Long boardId);
     List<BoardImg> updateBoardImgs(Long boardId, List<MultipartFile> files);
     List<BoardImg> getBoardImgs(Long boardId);
+    void checkExistImgUrl(Long boardId, String chosenImgUrl);
 }

--- a/src/main/java/com/sscanner/team/board/service/BoardImgServiceImpl.java
+++ b/src/main/java/com/sscanner/team/board/service/BoardImgServiceImpl.java
@@ -60,4 +60,11 @@ public class BoardImgServiceImpl implements BoardImgService{
 
         return boardImgs;
     }
+
+    public void checkExistImgUrl(Long boardId, String chosenImgUrl) {
+        boolean isExist = boardImgRepository.existsByBoardIdAndAndBoardImgUrl(boardId, chosenImgUrl);
+        if(!isExist) {
+            throw new BadRequestException(NOT_EXIST_BOARD_IMG);
+        }
+    }
 }

--- a/src/main/java/com/sscanner/team/board/service/BoardService.java
+++ b/src/main/java/com/sscanner/team/board/service/BoardService.java
@@ -1,13 +1,16 @@
 package com.sscanner.team.board.service;
 
+import com.sscanner.team.admin.responsedto.AdminBoardInfoResponseDTO;
 import com.sscanner.team.board.entity.Board;
 import com.sscanner.team.board.requestdto.BoardCreateRequestDTO;
 import com.sscanner.team.board.requestdto.BoardUpdateRequestDTO;
 import com.sscanner.team.board.responsedto.BoardListResponseDTO;
 import com.sscanner.team.board.responsedto.BoardLocationInfoResponseDTO;
 import com.sscanner.team.board.responsedto.BoardResponseDTO;
+import com.sscanner.team.board.type.ApprovalStatus;
 import com.sscanner.team.board.type.BoardCategory;
 import com.sscanner.team.trashcan.type.TrashCategory;
+import org.springframework.data.domain.Page;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -24,4 +27,6 @@ public interface BoardService {
     BoardResponseDTO getBoardDetailed(Long boardId);
     BoardLocationInfoResponseDTO getBoardLocationInfo(Long boardId);
     Board getBoard(Long boardId);
+    Page<AdminBoardInfoResponseDTO> getBoardsForAdmin(ApprovalStatus approvalStatus, TrashCategory trashCategory,
+                                                      BoardCategory boardCategory, Integer page, Integer size);
 }

--- a/src/main/java/com/sscanner/team/board/service/BoardServiceImpl.java
+++ b/src/main/java/com/sscanner/team/board/service/BoardServiceImpl.java
@@ -1,5 +1,6 @@
 package com.sscanner.team.board.service;
 
+import com.sscanner.team.admin.responsedto.AdminBoardInfoResponseDTO;
 import com.sscanner.team.user.entity.User;
 import com.sscanner.team.board.entity.Board;
 import com.sscanner.team.board.entity.BoardImg;
@@ -10,6 +11,7 @@ import com.sscanner.team.board.responsedto.BoardInfoResponseDTO;
 import com.sscanner.team.board.responsedto.BoardListResponseDTO;
 import com.sscanner.team.board.responsedto.BoardLocationInfoResponseDTO;
 import com.sscanner.team.board.responsedto.BoardResponseDTO;
+import com.sscanner.team.board.type.ApprovalStatus;
 import com.sscanner.team.board.type.BoardCategory;
 import com.sscanner.team.global.exception.BadRequestException;
 import com.sscanner.team.global.utils.UserUtils;
@@ -152,6 +154,20 @@ public class BoardServiceImpl implements BoardService{
         return boardRepository
                 .findById(boardId)
                 .orElseThrow(() -> new BadRequestException(NOT_EXIST_BOARD));
+    }
+
+    @Override
+    public Page<AdminBoardInfoResponseDTO> getBoardsForAdmin(ApprovalStatus approvalStatus, TrashCategory trashCategory,
+                                                      BoardCategory boardCategory, Integer page, Integer size) {
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.Direction.DESC, "updatedAt");
+
+        Page<Board> boards =
+                boardRepository.findAllByStatusAndCategories(approvalStatus, boardCategory, trashCategory, pageRequest);
+
+        return boards.map(board -> {
+            List<BoardImg> boardImgs = boardImgService.getBoardImgs(board.getId());
+            return AdminBoardInfoResponseDTO.of(board, boardImgs.get(0).getBoardImgUrl());
+        });
     }
 
     private void isMatchAuthor(User user, Board board) {

--- a/src/main/java/com/sscanner/team/global/configure/SecurityConfig.java
+++ b/src/main/java/com/sscanner/team/global/configure/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
         // 경로별 인가
         http.authorizeHttpRequests((authorize)->
                 authorize.requestMatchers("/login","/", "health","api/users/join","/sms/**","/api/users/reset-password","/api/users/find-id").permitAll()
-                        .requestMatchers("/admin").hasRole("ADMIN")
+                        .requestMatchers("/api/admin/boards/**").hasAuthority("ADMIN")
                         .anyRequest().authenticated()
         );
 

--- a/src/main/java/com/sscanner/team/trashcan/entity/Trashcan.java
+++ b/src/main/java/com/sscanner/team/trashcan/entity/Trashcan.java
@@ -66,4 +66,7 @@ public class Trashcan extends BaseEntity {
         this.trashCategory = requestDto.trashCategory();
     }
 
+    public void changeTrashcanStatus(TrashcanStatus updatedTrashcanStatus) {
+        this.trashcanStatus = updatedTrashcanStatus;
+    }
 }

--- a/src/main/java/com/sscanner/team/trashcan/entity/TrashcanImg.java
+++ b/src/main/java/com/sscanner/team/trashcan/entity/TrashcanImg.java
@@ -38,5 +38,7 @@ public class TrashcanImg extends BaseEntity {
 
     }
 
-
+    public void changeImgUrl(String chosenImgUrl) {
+        this.trashcanImgUrl = chosenImgUrl;
+    }
 }

--- a/src/main/java/com/sscanner/team/trashcan/service/TrashcanService.java
+++ b/src/main/java/com/sscanner/team/trashcan/service/TrashcanService.java
@@ -1,5 +1,6 @@
 package com.sscanner.team.trashcan.service;
 
+import com.sscanner.team.trashcan.entity.Trashcan;
 import com.sscanner.team.trashcan.requestDto.RegisterTrashcanRequestDto;
 import com.sscanner.team.trashcan.requestDto.UpdateTrashcanRequestDto;
 import com.sscanner.team.trashcan.responseDto.TrashcanResponseDto;
@@ -24,6 +25,9 @@ public interface TrashcanService {
 
     TrashcanResponseDto updateTrashcanInfo(Long trashcanId, UpdateTrashcanRequestDto requestDto);
 
+    Trashcan getTrashcanById(Long trashcanId);
 
     List<TrashcanResponseDto> getTrashcanByCoordinate(BigDecimal latitude, BigDecimal longitude);
+
+    void saveTrashcan(Trashcan trashcan);
 }

--- a/src/main/java/com/sscanner/team/trashcan/service/TrashcanServiceImpl.java
+++ b/src/main/java/com/sscanner/team/trashcan/service/TrashcanServiceImpl.java
@@ -56,7 +56,7 @@ public class TrashcanServiceImpl implements TrashcanService {
         return TrashcanWithImgResponseDto.of(trashcan, trashcanImg);
     }
 
-    private Trashcan getTrashcanById(Long trashcanId) {
+    public Trashcan getTrashcanById(Long trashcanId) {
         return trashcanRepository.findById(trashcanId)
                 .orElseThrow(() -> new BadRequestException(NOT_EXIST_TRASHCAN_ID));
     }
@@ -123,4 +123,8 @@ public class TrashcanServiceImpl implements TrashcanService {
         return TrashcanResponseDto.from(trashcan);
     }
 
+    @Override
+    public void saveTrashcan(Trashcan trashcan) {
+        trashcanRepository.save(trashcan);
+    }
 }


### PR DESCRIPTION
resolved : #38 
## 📌 과제 설명
어드민 관련 API 작성

## 👩‍💻 요구 사항과 구현 내용
- 게시글의 승인 상태를 조회 조건에 추가해서 페이징 처리하여 게시글 목록을 조회하였습니다.
- 수정 게시글과 수정, 삭제 게시글의 상세 정보 형태가 달라서 따로 API를 구현하였습니다.
- 게시글 반영 API를 작성하였습니다.
- 게시글 반영은 추가, 수정, 삭제 이렇게 게시글 유형마다 다르게 로직이 진행되게 하였습니다.
- securityConfig에서 hasRole은 prefix에 ROLE을 자동으로 붙여 비교하기 어려워 hasAuthority로 변경하였습니다.

## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
- 게시글 유형마다 다른 로직을 실행하는 부분을 if문에서 switch문으로 변경
- 디버깅을 용이하게 하기 위해 default는 예외를 던짐

## ✅ PR 포인트 & 궁금한 점
- 게시글 반영하는 부분의 로직에 집중해서 보시면 좋을 것 같아요
